### PR TITLE
관리자 페이지 로그아웃 시 모든 쿠키 삭제

### DIFF
--- a/src/components/layout/admin/AdminHeader.tsx
+++ b/src/components/layout/admin/AdminHeader.tsx
@@ -13,7 +13,8 @@ const AdminHeader = () => {
 
   const handleLogout = async () => {
     removeCookie('isAdmin');
-    removeCookie('tokens');
+    removeCookie('accessToken');
+    removeCookie('refreshToken');
     await router.replace('/');
     router.reload();
   };


### PR DESCRIPTION
# 📍 이슈 번호
#32 
<!-- 이슈 완료 시 close 추가 -->

# 📚 작업 내용
관리자 페이지 로그아웃 시 accessToken, refreshToken, isAdmin 쿠키 값을
모두 삭제하도록 수정하였습니다.
