### PR TITLE
상세페이지 옵션 선택 파트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "react-icons": "^4.8.0",
         "react-modal": "^3.16.1",
         "react-redux": "^8.0.5",
-        "react-select": "^5.7.1",
+        "react-select": "^5.7.2",
         "swiper": "^9.1.0",
         "typescript": "4.9.5"
       },
@@ -4261,9 +4261,9 @@
       "license": "MIT"
     },
     "node_modules/react-select": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.1.tgz",
-      "integrity": "sha512-u/brzm3B6vgI+PtxNyE4/18kXgaf6bn5sOAjKhaQ54EItBfW41SRLH1AJC5fefPnGM4JmMcM51t/HAVCi5GrpQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.2.tgz",
+      "integrity": "sha512-cTlJkQ8YjV6T/js8wW0owTzht0hHGABh29vjLscY4HfZGkv7hc3FFTmRp9NzY/Ib1uQ36GieAKEjxpHdpCFpcA==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -7488,9 +7488,9 @@
       }
     },
     "react-select": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.1.tgz",
-      "integrity": "sha512-u/brzm3B6vgI+PtxNyE4/18kXgaf6bn5sOAjKhaQ54EItBfW41SRLH1AJC5fefPnGM4JmMcM51t/HAVCi5GrpQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.2.tgz",
+      "integrity": "sha512-cTlJkQ8YjV6T/js8wW0owTzht0hHGABh29vjLscY4HfZGkv7hc3FFTmRp9NzY/Ib1uQ36GieAKEjxpHdpCFpcA==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-icons": "^4.8.0",
         "react-modal": "^3.16.1",
         "react-redux": "^8.0.5",
+        "react-select": "^5.7.1",
         "swiper": "^9.1.0",
         "typescript": "4.9.5"
       },
@@ -321,6 +322,19 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.4.tgz",
+      "integrity": "sha512-SQOeVbMwb1di+mVWWJLpsUTToKfqVNioXys011beCAhyOIFtS+GQoW4EQSneuxzmQKddExDwQ+X0hLl4lJJaSQ=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.5.tgz",
+      "integrity": "sha512-+sAUfpQ3Frz+VCbPCqj+cZzvEESy3fjSeT/pDWkYCWOBXYNNKZfuVsHuv8/JO2zze8+Eb/Q7a6hZVgzS81fLbQ==",
+      "dependencies": {
+        "@floating-ui/core": "^1.2.4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3566,6 +3580,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "dev": true,
@@ -4241,6 +4260,26 @@
       "version": "18.2.0",
       "license": "MIT"
     },
+    "node_modules/react-select": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.1.tgz",
+      "integrity": "sha512-u/brzm3B6vgI+PtxNyE4/18kXgaf6bn5sOAjKhaQ54EItBfW41SRLH1AJC5fefPnGM4JmMcM51t/HAVCi5GrpQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "license": "BSD-3-Clause",
@@ -4913,6 +4952,19 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "license": "MIT",
@@ -5248,6 +5300,19 @@
     "@eslint/js": {
       "version": "8.35.0",
       "dev": true
+    },
+    "@floating-ui/core": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.4.tgz",
+      "integrity": "sha512-SQOeVbMwb1di+mVWWJLpsUTToKfqVNioXys011beCAhyOIFtS+GQoW4EQSneuxzmQKddExDwQ+X0hLl4lJJaSQ=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.5.tgz",
+      "integrity": "sha512-+sAUfpQ3Frz+VCbPCqj+cZzvEESy3fjSeT/pDWkYCWOBXYNNKZfuVsHuv8/JO2zze8+Eb/Q7a6hZVgzS81fLbQ==",
+      "requires": {
+        "@floating-ui/core": "^1.2.4"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -7077,6 +7142,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
     "merge-stream": {
       "version": "2.0.0",
       "dev": true
@@ -7415,6 +7485,22 @@
         "react-is": {
           "version": "18.2.0"
         }
+      }
+    },
+    "react-select": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.1.tgz",
+      "integrity": "sha512-u/brzm3B6vgI+PtxNyE4/18kXgaf6bn5sOAjKhaQ54EItBfW41SRLH1AJC5fefPnGM4JmMcM51t/HAVCi5GrpQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.1.2"
       }
     },
     "react-transition-group": {
@@ -7793,6 +7879,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
     },
     "use-sync-external-store": {
       "version": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-icons": "^4.8.0",
     "react-modal": "^3.16.1",
     "react-redux": "^8.0.5",
+    "react-select": "^5.7.1",
     "swiper": "^9.1.0",
     "typescript": "4.9.5"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-icons": "^4.8.0",
     "react-modal": "^3.16.1",
     "react-redux": "^8.0.5",
-    "react-select": "^5.7.1",
+    "react-select": "^5.7.2",
     "swiper": "^9.1.0",
     "typescript": "4.9.5"
   },

--- a/pages/product/[id].tsx
+++ b/pages/product/[id].tsx
@@ -6,6 +6,8 @@ import { IDetail } from '@/interfaces/product';
 import { formatPrice } from '@/utils/format';
 import { AiOutlineHeart } from 'react-icons/ai';
 
+import Select from 'react-select';
+
 const tempData: IDetail = {
   productId: '1',
   title: '호주 시드니 8일',
@@ -20,21 +22,42 @@ const tempData: IDetail = {
 
 const ProductDetail = () => {
   const router = useRouter();
-  const [date, setDate] = useState('');
+  const [date, setDate] = useState<string>();
   const [single, setSingle] = useState('');
   const [items, setItems] = useState([]);
   const [counts, setCounts] = useState(1);
 
-  const dateSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setDate(e.target.value);
+  const DateOptions = [
+    {
+      value: '2023/05/30(화)출발 ~ 06/13(화)도착',
+      label: '2023/05/30(화)출발 ~ 06/13(화)도착',
+    },
+    {
+      value: '2023/06/13(화)출발 ~ 06/27(화)도착',
+      label: '2023/06/13(화)출발 ~ 06/27(화)도착',
+    },
+    {
+      value: '2023/09/12(화)출발 ~ 09/13(화)도착',
+      label: '2023/09/12(화)출발 ~ 09/13(화)도착',
+    },
+    {
+      value: '2023/09/26(화)출발 ~ 10/10(화)도착',
+      label: '2023/09/26(화)출발 ~ 10/10(화)도착',
+    },
+  ];
+
+  const dateSelect = (option: any) => {
+    setDate(option.value);
+    console.log('date ' + date);
+    console.log('option ' + option.value);
 
     const newItem = {
       date,
       counts,
     };
+
     setItems([newItem as never, ...items]);
   };
-  console.log(items);
 
   const singleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSingle(e.target.value);
@@ -55,23 +78,12 @@ const ProductDetail = () => {
           <p className="title">여행 항공</p>
           <p className="detail">{tempData?.airline}</p>
           <p className="dropTitle">출발일</p>
-          <select onChange={dateSelect}>
-            <option selected disabled hidden>
-              출발일을 선택해 주세요 (필수)
-            </option>
-            <option value="2023/05/30(화)출발 ~ 06/13(화)도착">
-              2023/05/30(화)출발 ~ 06/13(화)도착
-            </option>
-            <option value="2023/06/13(화)출발 ~ 06/27(화)도착">
-              2023/06/13(화)출발 ~ 06/27(화)도착
-            </option>
-            <option value="2023/09/12(화)출발 ~ 09/13(화)도착">
-              2023/09/12(화)출발 ~ 09/13(화)도착
-            </option>
-            <option value="2023/09/26(화)출발 ~ 10/10(화)도착">
-              2023/09/26(화)출발 ~ 10/10(화)도착
-            </option>
-          </select>
+
+          <Select
+            onChange={dateSelect}
+            options={DateOptions}
+            placeholder="출발일을 선택해 주세요 (필수)"
+          />
 
           <p className="dropTitle">싱글차지</p>
           <select onChange={singleSelect}>

--- a/pages/product/[id].tsx
+++ b/pages/product/[id].tsx
@@ -29,31 +29,31 @@ const ProductDetail = () => {
 
   const DateOptions = [
     {
-      value: '2023/05/30(화)출발 ~ 06/13(화)도착',
+      value: 1,
       label: '2023/05/30(화)출발 ~ 06/13(화)도착',
     },
     {
-      value: '2023/06/13(화)출발 ~ 06/27(화)도착',
+      value: 1,
       label: '2023/06/13(화)출발 ~ 06/27(화)도착',
     },
     {
-      value: '2023/09/12(화)출발 ~ 09/13(화)도착',
+      value: 1,
       label: '2023/09/12(화)출발 ~ 09/13(화)도착',
     },
     {
-      value: '2023/09/26(화)출발 ~ 10/10(화)도착',
+      value: 1,
       label: '2023/09/26(화)출발 ~ 10/10(화)도착',
     },
   ];
 
   const dateSelect = (option: any) => {
-    setDate(option.value);
-    console.log('date ' + date);
-    console.log('option ' + option.value);
+    // setDate(option.value);
+    const optionDate = option.label;
+    const count = option.value;
 
     const newItem = {
-      date,
-      counts,
+      optionDate,
+      count,
     };
 
     setItems([newItem as never, ...items]);
@@ -96,24 +96,25 @@ const ProductDetail = () => {
           </select>
 
           {items.length > 0
-            ? items.map((item: { date: string; counts: number }, i: React.Key) => {
+            ? items.map((item: { optionDate: string; count: number }, i: React.Key) => {
                 return (
                   <ItemContent key={i}>
-                    <p className="itemTitle">{item?.date}</p>
+                    <p className="itemTitle">{item?.optionDate}</p>
                     <button
                       onClick={() => {
-                        if (counts > 1) {
-                          item.counts - 1;
+                        if (item.count > 1) {
+                          item.count - 1;
                         }
                       }}
                     >
                       -
                     </button>
-                    <p>{item.counts}</p>
+                    <p>{item.count}</p>
                     <button
                       onClick={() => {
-                        // item.counts + 1;
-                        setCounts(counts + 1);
+                        item.count += 1;
+                        console.log(item.count);
+                        // setCounts(item.count + 1);
                       }}
                     >
                       +

--- a/pages/product/[id].tsx
+++ b/pages/product/[id].tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import styled from 'styled-components';
+import styled from '@emotion/styled';
 import Image from '@/../../src/components/common/Image';
 import { IDetail } from '@/interfaces/product';
 import { formatPrice } from '@/utils/format';

--- a/pages/product/[id].tsx
+++ b/pages/product/[id].tsx
@@ -1,7 +1,191 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
+import Image from '@/../../src/components/common/Image';
+import { IDetail } from '@/interfaces/product';
+import { formatPrice } from '@/utils/format';
+import { AiOutlineHeart } from 'react-icons/ai';
+
+const tempData: IDetail = {
+  productId: '1',
+  title: '호주 시드니 8일',
+  price: '2699000',
+  imagePath: 'https://picsum.photos/id/10/350/350',
+  summary:
+    '4050 여성들 누구나 참가하는 조지아 일주 여행 코카서스의 백미 조지아를 샅샅히 둘러보는 상품 패키지의 안전함과 자유여행의 즐거움을 동시에~',
+  area: '트빌리시/카즈베기/바르지아/보르조미/쿠타이시/메스티아/바투미/고리/우플리시케/시그나기/크바렐리',
+  point: '포함투어 12개(타사상품 비교必)/No팁/No쇼핑/No옵션',
+  airline: '인천-트빌리시 왕복 항공',
+};
 
 const ProductDetail = () => {
-  return <div>ProductDetail</div>;
+  const router = useRouter();
+  const [date, setDate] = useState('');
+  const [single, setSingle] = useState('');
+  const [items, setItems] = useState([]);
+  const [counts, setCounts] = useState(1);
+
+  const dateSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setDate(e.target.value);
+
+    const newItem = {
+      date,
+      counts,
+    };
+    setItems([newItem as never, ...items]);
+  };
+  console.log(items);
+
+  const singleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSingle(e.target.value);
+  };
+
+  return (
+    <DetailContent>
+      <Simple>
+        <Image src={tempData?.imagePath} alt="product image" width="525" height="525" />
+        <TextContent>
+          <h2>{tempData?.title}</h2>
+          <p className="price">{formatPrice(tempData?.price)}</p>
+          <p className="summary">{tempData?.summary}</p>
+          <p className="title">여행 지역</p>
+          <p className="detail">{tempData?.area}</p>
+          <p className="title">여행 특징</p>
+          <p className="detail">{tempData?.point}</p>
+          <p className="title">여행 항공</p>
+          <p className="detail">{tempData?.airline}</p>
+          <p className="dropTitle">출발일</p>
+          <select onChange={dateSelect}>
+            <option selected disabled hidden>
+              출발일을 선택해 주세요 (필수)
+            </option>
+            <option value="2023/05/30(화)출발 ~ 06/13(화)도착">
+              2023/05/30(화)출발 ~ 06/13(화)도착
+            </option>
+            <option value="2023/06/13(화)출발 ~ 06/27(화)도착">
+              2023/06/13(화)출발 ~ 06/27(화)도착
+            </option>
+            <option value="2023/09/12(화)출발 ~ 09/13(화)도착">
+              2023/09/12(화)출발 ~ 09/13(화)도착
+            </option>
+            <option value="2023/09/26(화)출발 ~ 10/10(화)도착">
+              2023/09/26(화)출발 ~ 10/10(화)도착
+            </option>
+          </select>
+
+          <p className="dropTitle">싱글차지</p>
+          <select onChange={singleSelect}>
+            <option selected hidden disabled>
+              싱글룸을 이용하려면 선택해 주세요 (선택)
+            </option>
+            <option value="1인 싱글룸 사용시 추가">
+              1인 싱글룸 사용시 추가 {formatPrice('540000')}
+            </option>
+          </select>
+
+          {items.length > 0
+            ? items.map((item: { date: string; counts: number }, i: React.Key) => {
+                return (
+                  <ItemContent key={i}>
+                    <p className="itemTitle">{item?.date}</p>
+                    <button
+                      onClick={() => {
+                        if (counts > 1) {
+                          item.counts - 1;
+                        }
+                      }}
+                    >
+                      -
+                    </button>
+                    <p>{item.counts}</p>
+                    <button
+                      onClick={() => {
+                        // item.counts + 1;
+                        setCounts(counts + 1);
+                      }}
+                    >
+                      +
+                    </button>
+                    <p>{formatPrice(tempData.price)}</p>
+                  </ItemContent>
+                );
+              })
+            : null}
+
+          {single !== '' ? (
+            <ItemContent>
+              <p>{single}</p>
+              <p>{formatPrice('540000')}</p>
+            </ItemContent>
+          ) : null}
+
+          <button>예약하기</button>
+          <button>관심상품</button>
+          <button>
+            <AiOutlineHeart />
+          </button>
+        </TextContent>
+      </Simple>
+    </DetailContent>
+  );
 };
 
 export default ProductDetail;
+
+const DetailContent = styled.div``;
+
+const Simple = styled.div`
+  display: flex;
+  gap: 100px;
+  justify-content: center;
+`;
+
+const TextContent = styled.div`
+  width: 450px;
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 500;
+    margin-bottom: 1rem;
+  }
+  .price {
+    font-size: 1.5rem;
+    font-weight: 500;
+    border-bottom: 1px solid rgba(33, 37, 41, 0.2);
+    color: #4581f8;
+    padding-bottom: 24px;
+    margin-bottom: 24px;
+  }
+  .summary {
+    font-size: 1.2rem;
+    width: 80%;
+    line-height: 1.8rem;
+    color: rgb(153, 153, 153);
+    margin-bottom: 24px;
+  }
+  .title {
+    font-weight: 500;
+    font-size: 1.1rem;
+    margin-bottom: 0.5rem;
+  }
+  .detail {
+    line-height: 1.5rem;
+    margin-bottom: 1rem;
+  }
+  .dropTitle {
+    font-weight: 500;
+    margin: 36px 0 10px;
+  }
+  select,
+  input {
+    width: 100%;
+    font-size: 1rem;
+    padding: 10px;
+  }
+`;
+
+const ItemContent = styled.div`
+  margin-top: 24px;
+  .itemTitle {
+    border-bottom: 1px solid #999;
+  }
+`;

--- a/pages/product/[id].tsx
+++ b/pages/product/[id].tsx
@@ -1,12 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 import Image from '@/../../src/components/common/Image';
 import { IDetail } from '@/interfaces/product';
 import { formatPrice } from '@/utils/format';
-import { AiOutlineHeart } from 'react-icons/ai';
 
-import Select from 'react-select';
+import { AiOutlineHeart } from 'react-icons/ai';
+import { RxCrossCircled } from 'react-icons/rx';
+
+import Select, { OnChangeValue } from 'react-select';
 
 const tempData: IDetail = {
   productId: '1',
@@ -20,12 +22,27 @@ const tempData: IDetail = {
   airline: '인천-트빌리시 왕복 항공',
 };
 
+interface IItemOption {
+  optionDate: string;
+}
+
+interface ICountType {
+  count: number;
+}
+
 const ProductDetail = () => {
   const router = useRouter();
-  const [date, setDate] = useState<string>();
+
   const [single, setSingle] = useState('');
-  const [items, setItems] = useState([]);
-  const [counts, setCounts] = useState(1);
+  const [singleCount, setSingleCount] = useState(1);
+
+  const [items, setItems] = useState<Array<IItemOption>>([]);
+  const [itemCounts, setItemCounts] = useState<Array<ICountType>>([]);
+
+  const [totalPrice, setTotalPrice] = useState(0);
+  const [totalMember, setTotalMember] = useState(0);
+
+  const productPrice = Number(tempData.price);
 
   const DateOptions = [
     {
@@ -46,21 +63,75 @@ const ProductDetail = () => {
     },
   ];
 
-  const dateSelect = (option: any) => {
-    // setDate(option.value);
-    const optionDate = option.label;
-    const count = option.value;
+  const SingleOption = [
+    {
+      value: 1,
+      label: `1인 싱글룸 사용시 추가 ${formatPrice('540000')}`,
+    },
+  ];
 
-    const newItem = {
-      optionDate,
-      count,
-    };
+  const dateSelect = (option: OnChangeValue<{ value: number; label: string }, false>) => {
+    const optionDate = option?.label as string;
+    const count = option?.value as number;
 
-    setItems([newItem as never, ...items]);
+    if (items.some((item) => item.optionDate === optionDate)) {
+      alert('이미 선택하신 옵션입니다.');
+    } else {
+      const newItem = {
+        optionDate,
+      };
+
+      const newCount = {
+        count,
+      };
+
+      setItems([newItem, ...items]);
+      setItemCounts([newCount, ...itemCounts]);
+      setTotalPrice(totalPrice + productPrice * count);
+      setTotalMember(totalMember + count);
+    }
   };
 
-  const singleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setSingle(e.target.value);
+  const singleSelect = (option: OnChangeValue<{ value: number; label: string }, false>) => {
+    if (single !== '') {
+      setSingleCount(singleCount + 1);
+      setTotalPrice(totalPrice + 540000);
+    } else {
+      setSingle(option?.label as string);
+      setSingleCount(option?.value as number);
+      setTotalPrice(totalPrice + 540000);
+    }
+  };
+
+  const plusClick = (i: number) => {
+    const plus = [...itemCounts];
+    plus[i].count += 1;
+    setItemCounts([...plus]);
+
+    setTotalPrice(totalPrice + productPrice);
+    setTotalMember(totalMember + 1);
+  };
+
+  const minusClick = (i: number) => {
+    const minus = [...itemCounts];
+    minus[i].count -= 1;
+    setItemCounts([...minus]);
+
+    setTotalPrice(totalPrice - productPrice);
+    setTotalMember(totalMember - 1);
+  };
+
+  const removeItem = (i: number) => {
+    setTotalPrice(totalPrice - productPrice * itemCounts[i]?.count);
+    setTotalMember(totalMember - itemCounts[i]?.count);
+
+    const itemRemove = [...items];
+    itemRemove.splice(i, 1);
+    setItems([...itemRemove]);
+
+    const countRemove = [...itemCounts];
+    countRemove.splice(i, 1);
+    setItemCounts([...countRemove]);
   };
 
   return (
@@ -86,40 +157,40 @@ const ProductDetail = () => {
           />
 
           <p className="dropTitle">싱글차지</p>
-          <select onChange={singleSelect}>
-            <option selected hidden disabled>
-              싱글룸을 이용하려면 선택해 주세요 (선택)
-            </option>
-            <option value="1인 싱글룸 사용시 추가">
-              1인 싱글룸 사용시 추가 {formatPrice('540000')}
-            </option>
-          </select>
+          <Select
+            onChange={singleSelect}
+            options={SingleOption}
+            placeholder="싱글룸을 이용하려면 선택해 주세요 (선택)"
+            className="singleSelect"
+          />
 
           {items.length > 0
-            ? items.map((item: { optionDate: string; count: number }, i: React.Key) => {
+            ? items.map((item, i: number) => {
                 return (
                   <ItemContent key={i}>
-                    <p className="itemTitle">{item?.optionDate}</p>
+                    <p className="itemTitle">
+                      {item?.optionDate} <RxCrossCircled onClick={() => removeItem(i)} />
+                    </p>
                     <button
                       onClick={() => {
-                        if (item.count > 1) {
-                          item.count - 1;
+                        if (itemCounts[i].count > 1) {
+                          minusClick(i);
                         }
                       }}
                     >
                       -
                     </button>
-                    <p>{item.count}</p>
+                    <p className="count">{itemCounts[i].count}</p>
                     <button
                       onClick={() => {
-                        item.count += 1;
-                        console.log(item.count);
-                        // setCounts(item.count + 1);
+                        plusClick(i);
                       }}
                     >
                       +
                     </button>
-                    <p>{formatPrice(tempData.price)}</p>
+                    <p className="itemPrice">
+                      {formatPrice(`${productPrice * itemCounts[i].count}`)}
+                    </p>
                   </ItemContent>
                 );
               })
@@ -127,9 +198,43 @@ const ProductDetail = () => {
 
           {single !== '' ? (
             <ItemContent>
-              <p>{single}</p>
-              <p>{formatPrice('540000')}</p>
+              <p className="itemTitle">
+                {single}{' '}
+                <RxCrossCircled
+                  onClick={() => {
+                    setTotalPrice(totalPrice - 540000 * singleCount);
+                    setSingle('');
+                  }}
+                />
+              </p>
+              <button
+                onClick={() => {
+                  if (singleCount > 1) {
+                    setSingleCount(singleCount - 1);
+                    setTotalPrice(totalPrice - 540000);
+                  }
+                }}
+              >
+                -
+              </button>
+              <p className="count">{singleCount}</p>
+              <button
+                onClick={() => {
+                  setSingleCount(singleCount + 1);
+                  setTotalPrice(totalPrice + 540000);
+                }}
+              >
+                +
+              </button>
+              <p className="itemPrice">{formatPrice(`${540000 * singleCount}`)}</p>
             </ItemContent>
+          ) : null}
+
+          {items.length > 0 || single !== '' ? (
+            <TotalContent>
+              <p>총 상품금액 ( {totalMember} 명 )</p>
+              <p className="totalPrice">{formatPrice(`${totalPrice}`)}</p>
+            </TotalContent>
           ) : null}
 
           <button>예약하기</button>
@@ -188,17 +293,43 @@ const TextContent = styled.div`
     font-weight: 500;
     margin: 36px 0 10px;
   }
-  select,
-  input {
-    width: 100%;
-    font-size: 1rem;
-    padding: 10px;
+  .singleSelect {
+    margin-bottom: 40px;
   }
 `;
 
 const ItemContent = styled.div`
-  margin-top: 24px;
+  margin-top: 20px;
+  padding: 15px;
+  background-color: rgba(33, 37, 41, 0.1);
   .itemTitle {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
     border-bottom: 1px solid #999;
+  }
+  .count {
+    display: inline-block;
+    margin: auto 15px;
+  }
+  .itemPrice {
+    display: inline-block;
+    float: right;
+  }
+  svg {
+    float: right;
+    font-size: 1.2rem;
+  }
+`;
+
+const TotalContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 35px 0;
+  p {
+    margin: auto 0;
+  }
+  .totalPrice {
+    color: #4581f8;
+    font-size: 1.4rem;
   }
 `;

--- a/src/components/Product/index.tsx
+++ b/src/components/Product/index.tsx
@@ -14,15 +14,7 @@ const ProductItem = ({ data }: Props) => {
   const router = useRouter();
 
   const handleClick = () => {
-    router.push(
-      {
-        pathname: ROUTES.PRODUCT_BY_ID(data.productId),
-        query: {
-          ...data,
-        },
-      },
-      `${ROUTES.PRODUCT_BY_ID(data.productId)}`,
-    );
+    router.push(ROUTES.PRODUCT_BY_ID(data.productId));
   };
 
   return (

--- a/src/components/Product/index.tsx
+++ b/src/components/Product/index.tsx
@@ -14,7 +14,15 @@ const ProductItem = ({ data }: Props) => {
   const router = useRouter();
 
   const handleClick = () => {
-    router.push(ROUTES.PRODUCT_BY_ID(data.productId));
+    router.push(
+      {
+        pathname: ROUTES.PRODUCT_BY_ID(data.productId),
+        query: {
+          ...data,
+        },
+      },
+      `${ROUTES.PRODUCT_BY_ID(data.productId)}`,
+    );
   };
 
   return (

--- a/src/interfaces/product.ts
+++ b/src/interfaces/product.ts
@@ -4,3 +4,14 @@ export interface IProduct {
   price: string;
   imagePath: string;
 }
+
+export interface IDetail {
+  productId: string;
+  title: string;
+  price: string;
+  imagePath: string;
+  summary: string;
+  area: string;
+  point: string;
+  airline: string;
+}


### PR DESCRIPTION
# 📍 이슈 번호

#21 

<!-- 이슈 완료 시 close 추가 -->

# 📚 작업 내용
- 상세 페이지 상품의 간단한 정보 나열
- 상품 옵션 선택 및 삭제

https://user-images.githubusercontent.com/107393773/227448438-febfe6d0-9187-41b3-a985-d1dc5ec8bed8.mov

# 💬 특이 사항
- 옵션 선택에서 react-select를 사용하였습니다. ` npm i react-select ` 해주세욥
- 알럿창과 버튼은 공통 컴포넌트로 변경 예정입니다.
- 영상에서는 나오지 않았지만 싱글 옵션이 선택된 상태로 다시 선택하면 개수가 증가합니다.
- 전에 말한 내용대로 싱글 옵션은 인원수에 추가되지 않습니다.
- 상품 데이터는 제가 임의로 만든 것 입니다. api 는 후에 연결하도록 하겠습니당
