### PR TITLE
[커뮤니티]후기 목록 api 연결

### DIFF
--- a/pages/community/review/index.tsx
+++ b/pages/community/review/index.tsx
@@ -1,7 +1,5 @@
-import { instance } from '@/apis/instance';
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import data from '@/dummydata/communityReview.json';
 import { IReview } from '@/interfaces/community';
 import styled from '@emotion/styled';
 import { Pagination, TextField } from '@mui/material';
@@ -11,28 +9,37 @@ import SearchIcon from '@/../public/icons/Group.svg';
 import ReviewItem from '@/components/Community/ReviewItem';
 import CommunityRouter from '@/components/Community/CommunityRouter';
 import { ROUTES } from '@/constants/routes';
+import { getBoardList, getBoardSearchList } from '@/apis/community';
 
 const Review = () => {
   const router = useRouter();
   const [reviewData, setReviewData] = useState<Array<IReview>>([]);
   const [keyword, setKeyword] = useState('');
   const [page, setPage] = useState(1);
+  const [totalPage, setTotalPage] = useState(1);
 
   useEffect(() => {
     const getData = async () => {
-      await setReviewData(data.content);
+      const data = await getBoardList('TRAVEL_REVIEW', page);
+      setReviewData(data?.content);
+      setTotalPage(data.totalPages);
     };
     getData();
-  }, []);
+  }, [page]);
+
+  const getSearchData = async () => {
+    const searchData = await getBoardSearchList(keyword, 1);
+    setReviewData(searchData?.content);
+  };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if ((event.nativeEvent.isComposing === false && event.key) === 'Enter') {
-      console.log(keyword);
+      getSearchData();
     }
   };
 
-  const searchClick = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    console.log(keyword);
+  const searchClick = () => {
+    getSearchData();
   };
 
   const pageChange = (event: React.ChangeEvent<unknown>, value: number) => {
@@ -58,7 +65,7 @@ const Review = () => {
             onChange={(event) => setKeyword(event.target.value)}
             onKeyDown={handleKeyDown}
           />
-          <SearchIcon onClick={(e: React.KeyboardEvent<HTMLInputElement>) => searchClick(e)} />
+          <SearchIcon onClick={() => searchClick()} />
         </InputArea>
       </TopArea>
 
@@ -67,7 +74,7 @@ const Review = () => {
       </>
 
       <BottomArea>
-        {reviewData.length > 0 ? (
+        {reviewData && reviewData.length > 0 ? (
           reviewData.map((item) => <ReviewItem key={item.boardId} data={item} />)
         ) : (
           <h3>후기가 존재하지 않습니다.</h3>
@@ -75,7 +82,7 @@ const Review = () => {
       </BottomArea>
 
       <PageContent>
-        <Pagination count={10} color="primary" page={page} onChange={pageChange} />
+        <Pagination count={totalPage} color="primary" page={page} onChange={pageChange} />
       </PageContent>
     </ReviewContent>
   );

--- a/pages/community/review/index.tsx
+++ b/pages/community/review/index.tsx
@@ -19,12 +19,11 @@ const Review = () => {
   const [totalPage, setTotalPage] = useState(1);
 
   useEffect(() => {
-    const getData = async () => {
+    (async () => {
       const data = await getBoardList('TRAVEL_REVIEW', page);
       setReviewData(data?.content);
       setTotalPage(data.totalPages);
-    };
-    getData();
+    })();
   }, [page]);
 
   const getSearchData = async () => {

--- a/src/apis/community.ts
+++ b/src/apis/community.ts
@@ -1,0 +1,12 @@
+import { API_URLS } from '@/constants/apiUrls';
+import { instance } from './instance';
+
+export const getBoardList = async (type: string, pageNumber: number) => {
+  const { data } = await instance.get(API_URLS.BOARD(type, pageNumber));
+  return data;
+};
+
+export const getBoardSearchList = async (type: string, pageNumber: number) => {
+  const { data } = await instance.get(API_URLS.BOARD_SEARCH(type, pageNumber));
+  return data;
+};

--- a/src/apis/product.ts
+++ b/src/apis/product.ts
@@ -11,5 +11,5 @@ export const getProductList = async (
   const { data } = await instance.get(
     API_URLS.SEARCH_BY_KEYWORD(keyword, page, sort, people, dateOption),
   );
-  return data;
+  return data.data;
 };

--- a/src/apis/product.ts
+++ b/src/apis/product.ts
@@ -11,5 +11,5 @@ export const getProductList = async (
   const { data } = await instance.get(
     API_URLS.SEARCH_BY_KEYWORD(keyword, page, sort, people, dateOption),
   );
-  return data.data;
+  return data;
 };

--- a/src/constants/apiUrls.ts
+++ b/src/constants/apiUrls.ts
@@ -18,17 +18,11 @@ export const API_URLS = {
   BUY_LIST: (page: number) => `/buy/${page}`,
   CART: '/cart',
   ORDER: '/order',
-  BOARD: '/board',
+  BOARD: (type: string, pageNumber: number) => `/board?type=${type}&pageNumber=${pageNumber}`,
   BOARD_AUTH: (id: string) => `/board/authority/${id}`,
   BOARD_DETAIL: (id: string) => `/board/detail/${id}`,
-  BOARD_SEARCH: (
-    keyword: string,
-    page: number,
-    sort?: string,
-    people?: number,
-    dateOption?: string,
-  ) =>
-    `/board/search?keyword=${keyword}&page=${page}&sort=${sort}&people=${people}&dateOption=${dateOption}`,
+  BOARD_SEARCH: (keyword: string, pageNumber: number) =>
+    `/board/search?keyword=${keyword}&pageNumber=${pageNumber}`,
   CATEGORY: '/categories',
   CATEGORY_DETAIL: (id: string) => `/categories/${id}`,
   ADMIN: {},


### PR DESCRIPTION
# 📍 이슈 번호
#49 
<!-- 이슈 완료 시 close 추가 -->

# 📚 작업 내용
- 후기 목록 api 연결 (목록, 검색)

# 💬 특이 사항
- 현재 페이지 마다 후기 목록을 불러오는 api를 호출해서 검색한 후 페이지를 이동하면 검색 데이터가 아닌 전체 데이터의 해당 페이지가 불러집니다.
- 위 내용은 수정 예정입니다