### PR TITLE
[커뮤니티] 후기 상세 페이지 구현

### DIFF
--- a/pages/community/review/[id].tsx
+++ b/pages/community/review/[id].tsx
@@ -45,17 +45,39 @@ const ReviewDetail = () => {
         }),
       );
     } else {
-      router.push(ROUTES.REVIEW);
       return dispatch(
         setModal({
           isOpen: true,
-          onClickOk: () =>
+          text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
+          onClickOk: () => {
             dispatch(
               setModal({
                 isOpen: false,
               }),
             ),
-          text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
+              router.push(ROUTES.REVIEW);
+          },
+        }),
+      );
+    }
+  };
+
+  const moveLogin = () => {
+    if (cookies.accessToken && cookies.length > 0) {
+      router.push(ROUTES.REVIEW_ADD);
+    } else {
+      return dispatch(
+        setModal({
+          isOpen: true,
+          text: MESSAGES.COMMUNITY.MOVE_TO_LOGIN,
+          onClickOk: () => {
+            dispatch(
+              setModal({
+                isOpen: false,
+              }),
+            ),
+              router.push(ROUTES.LOGIN);
+          },
         }),
       );
     }
@@ -128,7 +150,7 @@ const ReviewDetail = () => {
 
       <ButtonContent>
         <button onClick={() => router.push(ROUTES.REVIEW)}>목록</button>
-        <button onClick={() => router.push(ROUTES.REVIEW_ADD)}>글쓰기</button>
+        <button onClick={() => moveLogin()}>글쓰기</button>
       </ButtonContent>
     </DetailContent>
   );

--- a/pages/community/review/[id].tsx
+++ b/pages/community/review/[id].tsx
@@ -1,33 +1,65 @@
 import { useRouter } from 'next/router';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import data from '@/dummydata/reviewDetail.json';
 import { IReviewDetail } from '@/interfaces/community';
 import styled from '@emotion/styled';
 import { formatUserName } from '@/utils/format';
 
 import { SlArrowUp, SlArrowDown } from 'react-icons/sl';
 import { ROUTES } from '@/constants/routes';
+import { deleteBoard, getBoardDetail } from '@/apis/community';
+import { useCookies } from 'react-cookie';
+import { useDispatch } from 'react-redux';
+import { setModal } from '@/store/modal';
+import { MESSAGES } from '@/constants/messages';
 
 const ReviewDetail = () => {
   const [detailData, setDetailData] = useState<IReviewDetail>();
   const router = useRouter();
-  const viewContainerRef = useRef<HTMLDivElement>(null);
+  const dispatch = useDispatch();
+  const [cookies, setCookies] = useCookies();
 
   useEffect(() => {
     const getData = async () => {
-      await setDetailData(data);
+      const data = await getBoardDetail(Number(router.query.id));
+      setDetailData(data);
     };
 
-    const innerHtml = () => {
-      if (viewContainerRef.current) {
-        viewContainerRef.current.innerHTML = '';
-        viewContainerRef.current.innerHTML += detailData?.boardContent;
-      }
-    };
     getData();
-    innerHtml();
   }, []);
+
+  const markUp = () => {
+    if (detailData?.boardContent !== undefined) {
+      return { __html: JSON.parse(detailData?.boardContent) };
+    }
+  };
+
+  const deleteHandler = async () => {
+    const deleteData = deleteBoard(Number(detailData?.boardId));
+    if ((await deleteData) === 'ERR_BAD_REQUEST') {
+      return dispatch(
+        setModal({
+          isOpen: true,
+          onClickOk: () => dispatch(setModal({ isOpen: false })),
+          text: MESSAGES.COMMUNITY.ERROR_DELETE,
+        }),
+      );
+    } else {
+      router.push(ROUTES.REVIEW);
+      return dispatch(
+        setModal({
+          isOpen: true,
+          onClickOk: () =>
+            dispatch(
+              setModal({
+                isOpen: false,
+              }),
+            ),
+          text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
+        }),
+      );
+    }
+  };
 
   return (
     <DetailContent>
@@ -43,43 +75,56 @@ const ReviewDetail = () => {
             {detailData?.createdDate} | {detailData?.updatedDate}
           </p>
         </div>
-        <div>
-          <button
-            onClick={() =>
-              router.push(
-                {
-                  pathname: ROUTES.REVIEW_EDIT,
-                  query: {
-                    boardId: detailData?.boardId,
+        {cookies.accessToken && cookies.length > 0 && detailData?.userName !== '관리자' ? (
+          <div>
+            <button
+              onClick={() =>
+                router.push(
+                  {
+                    pathname: ROUTES.REVIEW_EDIT,
+                    query: {
+                      boardId: detailData?.boardId,
+                    },
                   },
-                },
-                ROUTES.REVIEW_EDIT,
-              )
-            }
-          >
-            수정
-          </button>
-          <button className="delete">삭제</button>
-        </div>
+                  ROUTES.REVIEW_EDIT,
+                )
+              }
+            >
+              수정
+            </button>
+            <button
+              className="delete"
+              onClick={() => {
+                deleteHandler();
+              }}
+            >
+              삭제
+            </button>
+          </div>
+        ) : null}
       </SummaryContent>
 
       <MainContent>
-        <div ref={viewContainerRef} />
+        <div dangerouslySetInnerHTML={markUp()}></div>
       </MainContent>
 
-      <PrevNextContent>
-        <SlArrowUp size={20} />
-        <p onClick={() => router.push(ROUTES.REVIEW_BY_ID(Number(router.query.id) - 1))}>
-          이전 페이지
-        </p>
-      </PrevNextContent>
+      {router.query.i !== '0' ? (
+        <PrevNextContent>
+          <SlArrowUp size={20} />
+          <p onClick={() => router.push(ROUTES.REVIEW_BY_ID(Number(router.query.id) - 1))}>
+            이전 후기 보기
+          </p>
+        </PrevNextContent>
+      ) : null}
 
-      <PrevNextContent>
-        <SlArrowDown size={20} />
-        <p onClick={() => router.push(ROUTES.REVIEW_BY_ID(Number(router.query.id) + 1))}>
-          다음 페이지
-        </p>
-      </PrevNextContent>
+      {Number(router.query.i) !== Number(router.query.length) - 1 ? (
+        <PrevNextContent>
+          <SlArrowDown size={20} />
+          <p onClick={() => router.push(ROUTES.REVIEW_BY_ID(Number(router.query.id) + 1))}>
+            다음 후기 보기
+          </p>
+        </PrevNextContent>
+      ) : null}
 
       <ButtonContent>
         <button onClick={() => router.push(ROUTES.REVIEW)}>목록</button>

--- a/pages/community/review/edit.tsx
+++ b/pages/community/review/edit.tsx
@@ -92,7 +92,7 @@ const ReviewEdit = () => {
               boardThumbnail: JSON.stringify(fileUrl),
               boardTitle: keyword,
             };
-            patchBoardEdit(boardId, data);
+            patchBoardEdit(Number(boardId), data);
           }}
         >
           저장

--- a/pages/community/review/index.tsx
+++ b/pages/community/review/index.tsx
@@ -74,7 +74,9 @@ const Review = () => {
 
       <BottomArea>
         {reviewData && reviewData.length > 0 ? (
-          reviewData.map((item) => <ReviewItem key={item.boardId} data={item} />)
+          reviewData.map((item, i) => (
+            <ReviewItem key={item.boardId} data={item} i={i} length={reviewData.length} />
+          ))
         ) : (
           <h3>후기가 존재하지 않습니다.</h3>
         )}

--- a/src/apis/community.ts
+++ b/src/apis/community.ts
@@ -32,3 +32,17 @@ export const patchBoardEdit = async (
   const res = await instance.patch(API_URLS.BOARD_EDIT(boardId), data);
   return res;
 };
+
+export const deleteBoard = async (boardID: number) => {
+  try {
+    const res = await instance.delete(API_URLS.BOARD_EDIT(boardID));
+    return res;
+  } catch (e: any) {
+    return e.code;
+  }
+};
+
+export const getBoardDetail = async (boardId: number) => {
+  const { data } = await instance.get(API_URLS.BOARD_DETAIL(boardId));
+  return data;
+};

--- a/src/components/Community/ReviewItem.tsx
+++ b/src/components/Community/ReviewItem.tsx
@@ -7,9 +7,11 @@ import React from 'react';
 
 interface Props {
   data: IReview;
+  i: number;
+  length: number;
 }
 
-const ReviewItem = ({ data }: Props) => {
+const ReviewItem = ({ data, i, length }: Props) => {
   const router = useRouter();
   const imageUrl = data.boardThumbnail;
 
@@ -22,6 +24,8 @@ const ReviewItem = ({ data }: Props) => {
             pathname: ROUTES.REVIEW_BY_ID(data.boardId),
             query: {
               id: data.boardId,
+              i: i,
+              length: length,
             },
           },
           ROUTES.REVIEW_BY_ID(data.boardId),

--- a/src/constants/apiUrls.ts
+++ b/src/constants/apiUrls.ts
@@ -20,7 +20,7 @@ export const API_URLS = {
   ORDER: '/order',
   BOARD: (type: string, pageNumber: number) => `/board?type=${type}&pageNumber=${pageNumber}`,
   BOARD_AUTH: (id: string) => `/board/authority/${id}`,
-  BOARD_DETAIL: (id: string) => `/board/detail/${id}`,
+  BOARD_DETAIL: (id: number) => `/board/detail/${id}`,
   BOARD_SEARCH: (keyword: string, pageNumber: number) =>
     `/board/search?keyword=${keyword}&pageNumber=${pageNumber}`,
   BOARD_ADD: '/board',

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -57,4 +57,9 @@ export const MESSAGES = {
   VALID_AUTH: '로그인된 계정입니다.\n로그아웃 후 이용해주세요.',
   CHANGE_INFO: '정보수정이 완료되었습니다.',
   MOVE_TO_SIGNUP: '계정이 없으신가요? 그렇다면 회원가입 페이지로 이동해 주세요.',
+  COMMUNITY: {
+    MOVE_TO_LOGIN: '회원 전용 메뉴입니다.\n로그인 후 이용해 주세요.',
+    ERROR_DELETE: '권한이 없어 삭제가 불가능합니다.',
+    COMPLETE_DELETE: '삭제가 완료되었습니다.',
+  },
 };


### PR DESCRIPTION
# 📍 이슈 번호
#69 
<!-- 이슈 완료 시 close 추가 -->

# 📚 작업 내용
- 관리자가 작성한 후기는 수정/삭제 버튼이 보이지 않습니다.
- 토큰이 없는 사용자는 수정/삭제 버튼이 보이지 않습니다.
- 글쓰기 버튼을 클릭하였을 때 토큰이 없으면 로그인 페이지로 이동합니다.
- 상세 페이지 하단에서 첫번째 후기 이면 `이전 후기 보기` 가 보이지 않습니다.
- 반대로 해당 리뷰가 마지막 후기 이면 `다음 후기 보기`가 보이지 않습니다.
- 삭제 버튼을 클릭하였을 때 에러가 반환되면 모달창을 띄워 권한이 없음을 알려줍니다.

# 💬 특이 사항
