### PR TITLE
[관리자] 커뮤니티 여행 후기 관리 구현

### DIFF
--- a/pages/admin/community/notice/[id].tsx
+++ b/pages/admin/community/notice/[id].tsx
@@ -27,32 +27,37 @@ const NoticeDetail = () => {
     })();
   }, []);
 
-  const deleteHandler = async () => {
-    const deleteData = await deleteBoard(Number(detailData?.boardId));
-    if ((await deleteData) === 'ERR_BAD_REQUEST') {
-      return dispatch(
-        setModal({
-          isOpen: true,
-          onClickOk: () => dispatch(setModal({ isOpen: false })),
-          text: MESSAGES.COMMUNITY.ERROR_DELETE,
-        }),
-      );
-    } else {
-      return dispatch(
-        setModal({
-          isOpen: true,
-          text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
-          onClickOk: () => {
-            dispatch(
+  const deleteHandler = () => {
+    return dispatch(
+      setModal({
+        isOpen: true,
+        onClickOk: async () => {
+          const deleteData = await deleteBoard(Number(detailData?.boardId));
+          if (deleteData === 'ERR_BAD_REQUEST') {
+            return dispatch(
               setModal({
-                isOpen: false,
+                isOpen: true,
+                onClickOk: () => dispatch(setModal({ isOpen: false })),
+                text: MESSAGES.COMMUNITY.ERROR_DELETE,
               }),
-            ),
-              router.push(ROUTES.ADMIN.REVIEW);
-          },
-        }),
-      );
-    }
+            );
+          } else {
+            return dispatch(
+              setModal({
+                isOpen: true,
+                onClickOk: () => {
+                  dispatch(setModal({ isOpen: false }));
+                  router.push(ROUTES.REVIEW);
+                },
+                text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
+              }),
+            );
+          }
+        },
+        onClickCancel: () => dispatch(setModal({ isOpen: false })),
+        text: MESSAGES.COMMUNITY.CONFIRM_DELETE,
+      }),
+    );
   };
 
   return (

--- a/pages/admin/community/notice/[id].tsx
+++ b/pages/admin/community/notice/[id].tsx
@@ -1,8 +1,139 @@
 import withAuth from '@/components/common/PrivateRouter';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+import DetailData from '@/dummydata/reviewDetail.json';
+import { IReviewDetail } from '@/interfaces/community';
+import { useRouter } from 'next/router';
+import { deleteBoard, getBoardDetail } from '@/apis/community';
+import styled from '@emotion/styled';
+import PageTitle from '@/components/common/PageTitle';
+import { Table, TableCell, TableRow } from '@mui/material';
+import Parser from 'html-react-parser';
+import { ROUTES } from '@/constants/routes';
+import { useDispatch } from 'react-redux';
+import { setModal } from '@/store/modal';
+import { MESSAGES } from '@/constants/messages';
 
 const NoticeDetail = () => {
-  return <div>NoticeDetail</div>;
+  const router = useRouter();
+  const [detailData, setDetailData] = useState<IReviewDetail>();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    (async () => {
+      // const data = await getBoardDetail(Number(router.query.id));
+      // setDetailData(data);
+      setDetailData(DetailData);
+    })();
+  }, []);
+
+  const deleteHandler = async () => {
+    const deleteData = await deleteBoard(Number(detailData?.boardId));
+    if ((await deleteData) === 'ERR_BAD_REQUEST') {
+      return dispatch(
+        setModal({
+          isOpen: true,
+          onClickOk: () => dispatch(setModal({ isOpen: false })),
+          text: MESSAGES.COMMUNITY.ERROR_DELETE,
+        }),
+      );
+    } else {
+      return dispatch(
+        setModal({
+          isOpen: true,
+          text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
+          onClickOk: () => {
+            dispatch(
+              setModal({
+                isOpen: false,
+              }),
+            ),
+              router.push(ROUTES.ADMIN.REVIEW);
+          },
+        }),
+      );
+    }
+  };
+
+  return (
+    <Container>
+      <PageTitle title="공지 상세 정보" fontSize="20px" padding="10px" />
+      <DetailContent>
+        <Table>
+          <TableRow>
+            <TableCell align="center" width="15%">
+              공지 제목
+            </TableCell>
+            <TableCell align="left" width="30%">
+              {detailData && detailData.boardTitle}
+            </TableCell>
+            <TableCell align="center">작성자</TableCell>
+            <TableCell align="left">{detailData && detailData.userName}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell align="center" width="15%">
+              작성일
+            </TableCell>
+            <TableCell align="left" width="30%">
+              {detailData && detailData.createdDate}
+            </TableCell>
+            <TableCell align="center">수정일</TableCell>
+            <TableCell align="left">{detailData && detailData.updatedDate}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell align="center" colSpan={4}>
+              {detailData && Parser(detailData.boardContent)}
+            </TableCell>
+          </TableRow>
+        </Table>
+        <ButtonContent>
+          <button className="white" onClick={() => router.push(ROUTES.ADMIN.REVIEW_EDIT)}>
+            수정
+          </button>
+          <button className="blue" onClick={() => deleteHandler()}>
+            삭제
+          </button>
+        </ButtonContent>
+      </DetailContent>
+    </Container>
+  );
 };
 
 export default withAuth(NoticeDetail);
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-sizing: border-box;
+  position: relative;
+`;
+
+const DetailContent = styled.div`
+  margin-top: 2rem;
+`;
+
+const ButtonContent = styled.div`
+  margin-bottom: 5px;
+  margin-top: 20px;
+  text-align: right;
+  button {
+    border-radius: 8px;
+    margin: auto;
+    width: 5rem;
+    height: 2rem;
+    font-weight: 600;
+    border: 1px solid #0cb1f3;
+  }
+  .white {
+    color: #0cb1f3;
+    background-color: #fff;
+    margin-right: 10px;
+  }
+  .blue {
+    color: #fff;
+    background-color: #0cb1f3;
+  }
+`;

--- a/pages/admin/community/notice/add.tsx
+++ b/pages/admin/community/notice/add.tsx
@@ -22,7 +22,7 @@ const NoticeAddForm = () => {
 
   const onSubmit = () => {
     const data = {
-      boardContent: JSON.stringify(editValue),
+      boardContent: editValue,
       boardThumbnail: '',
       boardTitle: keyword,
       boardType: '알려드려요',

--- a/pages/admin/community/notice/add.tsx
+++ b/pages/admin/community/notice/add.tsx
@@ -1,8 +1,162 @@
 import withAuth from '@/components/common/PrivateRouter';
-import React from 'react';
+import React, { useState } from 'react';
+
+import styled from '@emotion/styled';
+import { Button, TextField } from '@mui/material';
+import ArrowLeft from '@/../public/icons/arrow-left.svg';
+import { useRouter } from 'next/router';
+
+import { postBoardAdd } from '@/apis/community';
+import dayjs from 'dayjs';
+import { ROUTES } from '@/constants/routes';
+
+import dynamic from 'next/dynamic';
+
+const Editor = dynamic(() => import('@/components/common/Editor'), { ssr: false });
 
 const NoticeAddForm = () => {
-  return <div>NoticeAddForm</div>;
+  const router = useRouter();
+  const [keyword, setKeyword] = useState('');
+
+  const [editValue, setEditValue] = useState<string>('');
+
+  const onSubmit = () => {
+    const data = {
+      boardContent: JSON.stringify(editValue),
+      boardThumbnail: '',
+      boardTitle: keyword,
+      boardType: '알려드려요',
+    };
+
+    postBoardAdd(data);
+    router.push(ROUTES.ADMIN.REVIEW);
+  };
+
+  const now = dayjs();
+  const date = now.format('YYYY-MM-DD');
+
+  return (
+    <AddContent>
+      <BackRouter onClick={() => router.back()}>
+        <ArrowLeft />
+        <p>공지사항 관리</p>
+      </BackRouter>
+
+      <TitleContent>
+        <p>제목</p>
+        <TextField
+          placeholder="제목을 입력해 주세요."
+          className="title"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+        />
+      </TitleContent>
+
+      <UserContent>
+        <span className="user">관리자</span>
+        <span>{date}</span>
+      </UserContent>
+
+      <EditorContent>
+        <Editor htmlStr={editValue} setHtmlStr={setEditValue} />
+      </EditorContent>
+
+      <ButtonContent>
+        <button className="white" onClick={() => router.back()}>
+          취소
+        </button>
+        <button
+          className="blue"
+          onClick={() => {
+            onSubmit();
+          }}
+        >
+          저장
+        </button>
+      </ButtonContent>
+    </AddContent>
+  );
 };
 
 export default withAuth(NoticeAddForm);
+
+const AddContent = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-sizing: border-box;
+  position: relative;
+`;
+
+const BackRouter = styled.div`
+  display: flex;
+  margin-bottom: 50px;
+  svg {
+    width: 30px;
+    margin-right: 10px;
+  }
+  p {
+    margin: auto 0;
+    font-size: 1.3rem;
+    color: #878787;
+  }
+`;
+
+const TitleContent = styled.div`
+  display: flex;
+  margin-bottom: 20px;
+  p {
+    font-size: 1.2rem;
+    color: #878787;
+    margin: auto 15px auto 0;
+  }
+  .title {
+    width: 50%;
+    input {
+      padding: 5px;
+      border: none;
+    }
+  }
+`;
+
+const UserContent = styled.div`
+  color: #878787;
+  text-align: right;
+  margin-bottom: 20px;
+  margin-right: 5px;
+  .user {
+    margin-right: 10px;
+  }
+`;
+
+const EditorContent = styled.div`
+  height: 500px;
+  .rdw-editor-wrapper {
+    height: 100%;
+  }
+`;
+
+const ButtonContent = styled.div`
+  margin-bottom: 5px;
+  margin-top: 120px;
+  text-align: right;
+  button {
+    border-radius: 8px;
+    margin: auto;
+    width: 5rem;
+    height: 2rem;
+    font-weight: 600;
+    border: 1px solid #0cb1f3;
+  }
+  .white {
+    color: #0cb1f3;
+    background-color: #fff;
+    margin-right: 10px;
+  }
+  .blue {
+    color: #fff;
+    background-color: #0cb1f3;
+  }
+`;

--- a/pages/admin/community/notice/edit.tsx
+++ b/pages/admin/community/notice/edit.tsx
@@ -22,7 +22,7 @@ const NoticeEditForm = () => {
 
   const onSubmit = () => {
     const data = {
-      boardContent: JSON.stringify(editValue),
+      boardContent: editValue,
       boardThumbnail: '',
       boardTitle: keyword,
       boardType: '알려드려요',

--- a/pages/admin/community/notice/edit.tsx
+++ b/pages/admin/community/notice/edit.tsx
@@ -1,8 +1,162 @@
 import withAuth from '@/components/common/PrivateRouter';
-import React from 'react';
+import React, { useState } from 'react';
+
+import styled from '@emotion/styled';
+import { Button, TextField } from '@mui/material';
+import ArrowLeft from '@/../public/icons/arrow-left.svg';
+import { useRouter } from 'next/router';
+
+import { patchBoardEdit } from '@/apis/community';
+import dayjs from 'dayjs';
+import { ROUTES } from '@/constants/routes';
+
+import dynamic from 'next/dynamic';
+
+const Editor = dynamic(() => import('@/components/common/Editor'), { ssr: false });
 
 const NoticeEditForm = () => {
-  return <div>NoticeEditForm</div>;
+  const router = useRouter();
+  const [keyword, setKeyword] = useState('');
+
+  const [editValue, setEditValue] = useState<string>('');
+
+  const onSubmit = () => {
+    const data = {
+      boardContent: JSON.stringify(editValue),
+      boardThumbnail: '',
+      boardTitle: keyword,
+      boardType: '알려드려요',
+    };
+
+    patchBoardEdit(Number(router.query.id), data);
+    router.push(ROUTES.ADMIN.REVIEW);
+  };
+
+  const now = dayjs();
+  const date = now.format('YYYY-MM-DD');
+
+  return (
+    <EditContent>
+      <BackRouter onClick={() => router.back()}>
+        <ArrowLeft />
+        <p>공지사항 관리</p>
+      </BackRouter>
+
+      <TitleContent>
+        <p>제목</p>
+        <TextField
+          placeholder="제목을 입력해 주세요."
+          className="title"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+        />
+      </TitleContent>
+
+      <UserContent>
+        <span className="user">관리자</span>
+        <span>{date}</span>
+      </UserContent>
+
+      <EditorContent>
+        <Editor htmlStr={editValue} setHtmlStr={setEditValue} />
+      </EditorContent>
+
+      <ButtonContent>
+        <button className="white" onClick={() => router.back()}>
+          취소
+        </button>
+        <button
+          className="blue"
+          onClick={() => {
+            onSubmit();
+          }}
+        >
+          저장
+        </button>
+      </ButtonContent>
+    </EditContent>
+  );
 };
 
 export default withAuth(NoticeEditForm);
+
+const EditContent = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-sizing: border-box;
+  position: relative;
+`;
+
+const BackRouter = styled.div`
+  display: flex;
+  margin-bottom: 50px;
+  svg {
+    width: 30px;
+    margin-right: 10px;
+  }
+  p {
+    margin: auto 0;
+    font-size: 20px;
+    font-weight: 600;
+  }
+`;
+
+const TitleContent = styled.div`
+  display: flex;
+  margin-bottom: 20px;
+  p {
+    font-size: 1.2rem;
+    color: #878787;
+    margin: auto 15px auto 0;
+  }
+  .title {
+    width: 50%;
+    input {
+      padding: 5px;
+      border: none;
+    }
+  }
+`;
+
+const UserContent = styled.div`
+  color: #878787;
+  text-align: right;
+  margin-bottom: 20px;
+  margin-right: 5px;
+  .user {
+    margin-right: 10px;
+  }
+`;
+
+const EditorContent = styled.div`
+  height: 500px;
+  .rdw-editor-wrapper {
+    height: 100%;
+  }
+`;
+
+const ButtonContent = styled.div`
+  margin-bottom: 5px;
+  margin-top: 120px;
+  text-align: right;
+  button {
+    border-radius: 8px;
+    margin: auto;
+    width: 5rem;
+    height: 2rem;
+    font-weight: 600;
+    border: 1px solid #0cb1f3;
+  }
+  .white {
+    color: #0cb1f3;
+    background-color: #fff;
+    margin-right: 10px;
+  }
+  .blue {
+    color: #fff;
+    background-color: #0cb1f3;
+  }
+`;

--- a/pages/admin/community/notice/index.tsx
+++ b/pages/admin/community/notice/index.tsx
@@ -1,13 +1,190 @@
+import { getBoardList } from '@/apis/community';
+import AdminTableHead from '@/components/common/AdminTableHead';
 import PageTitle from '@/components/common/PageTitle';
 import withAuth from '@/components/common/PrivateRouter';
-import React from 'react';
+import { ROUTES } from '@/constants/routes';
+import { IReview } from '@/interfaces/community';
+import styled from '@emotion/styled';
+import { BsSearch } from 'react-icons/bs';
+import {
+  Button,
+  Pagination,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  TextField,
+} from '@mui/material';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import NoticeList from '@/dummydata/CommunityNotice.json';
 
 const Notice = () => {
+  const router = useRouter();
+  const [notice, setNotice] = useState<Array<IReview>>([]);
+  const [keyword, setKeyword] = useState('');
+  const [page, setPage] = useState(1);
+  const [totalPage, setTotalPage] = useState(1);
+
+  useEffect(() => {
+    (async () => {
+      // const noticeData =
+      //   keyword !== ''
+      //     ? await getBoardList('NOTICE', page)
+      //     : await getBoardList('NOTICE', page, keyword);
+      // setNotice(noticeData?.content);
+      // setTotalPage(noticeData.totalPages);
+      setNotice(NoticeList.content);
+      setTotalPage(NoticeList.totalPages);
+    })();
+  }, []);
+
+  const getSearchData = async () => {
+    const searchData = await getBoardList('NOTICE', 1, keyword);
+    setNotice(searchData?.content);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if ((event.nativeEvent.isComposing === false && event.key) === 'Enter') {
+      getSearchData();
+    }
+  };
+
+  const searchClick = () => {
+    getSearchData();
+  };
+
+  const pageChange = (event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+  };
+
   return (
-    <div>
-      <PageTitle title="공지사항 관리" />
-    </div>
+    <Container>
+      <PageTitle title="공지사항 관리" fontSize="20px" padding="10px" />
+      <InputArea>
+        <TextField
+          placeholder="검색어를 입력해 주세요."
+          className="search"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <Button variant="outlined" className="searchBtn" onClick={() => searchClick()}>
+          <BsSearch size={23} />
+        </Button>
+      </InputArea>
+      <TableWrap>
+        <Table>
+          <AdminTableHead titles={['번호', '제목', '작성자', '작성일']} />
+          <TableBody>
+            {notice && notice.length > 0 ? (
+              notice.map((item, idx) => (
+                <TableRow
+                  key={idx}
+                  style={{ cursor: 'pointer' }}
+                  hover
+                  onClick={() =>
+                    router.push(
+                      {
+                        pathname: ROUTES.ADMIN.NOTICE_BY_ID(String(item.boardId)),
+                        query: {
+                          id: item.boardId,
+                        },
+                      },
+                      ROUTES.ADMIN.NOTICE_BY_ID(String(item.boardId)),
+                    )
+                  }
+                >
+                  <TableCell align="center" width="200px">
+                    {(page - 1) * 10 + idx + 1}
+                  </TableCell>
+                  <TableCell align="center">{item.boardTitle}</TableCell>
+                  <TableCell align="center">{item.userName}</TableCell>
+                  <TableCell align="center">{item.createdDate}</TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={4}>
+                  <EmptyText>등록된 상품이 없습니다.</EmptyText>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+        <BottomArea>
+          {totalPage > 1 && (
+            <Pagination count={totalPage} color="primary" page={page} onChange={pageChange} />
+          )}
+          <Button
+            className="addBtn"
+            variant="outlined"
+            onClick={() => router.push(ROUTES.ADMIN.NOTICE_ADD)}
+          >
+            등록
+          </Button>
+        </BottomArea>
+      </TableWrap>
+    </Container>
   );
 };
 
 export default withAuth(Notice);
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-sizing: border-box;
+  position: relative;
+`;
+
+const TableWrap = styled.div`
+  height: calc(100% - 40px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  margin-top: 2rem;
+`;
+
+const EmptyText = styled.p`
+  width: 100%;
+  font-size: 16px;
+  display: flex;
+  justify-content: center;
+`;
+
+const InputArea = styled.div`
+  text-align: center;
+  position: absolute;
+  top: 25px;
+  right: 4%;
+  .search {
+    width: 20rem;
+    border-radius: 8px;
+    margin-right: 1rem;
+    input {
+      padding: 5px;
+      background-color: #fff;
+    }
+  }
+  .searchBtn {
+    padding: 4px;
+  }
+`;
+
+const BottomArea = styled.div`
+  width: 100%;
+  position: relative;
+  ul {
+    justify-content: center;
+  }
+  .addBtn {
+    position: absolute;
+    right: 10px;
+    top: 0;
+  }
+`;

--- a/pages/admin/community/review/[id].tsx
+++ b/pages/admin/community/review/[id].tsx
@@ -1,8 +1,138 @@
 import withAuth from '@/components/common/PrivateRouter';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+import DetailData from '@/dummydata/reviewDetail.json';
+import { IReviewDetail } from '@/interfaces/community';
+import { useRouter } from 'next/router';
+import { deleteBoard, getBoardDetail } from '@/apis/community';
+import styled from '@emotion/styled';
+import PageTitle from '@/components/common/PageTitle';
+import { Table, TableCell, TableRow } from '@mui/material';
+import Parser from 'html-react-parser';
+import { ROUTES } from '@/constants/routes';
+import { useDispatch } from 'react-redux';
+import { setModal } from '@/store/modal';
+import { MESSAGES } from '@/constants/messages';
 
 const ReviewDetail = () => {
-  return <div>ReviewDetail</div>;
+  const router = useRouter();
+  const [detailData, setDetailData] = useState<IReviewDetail>();
+  const dispatch = useDispatch();
+  useEffect(() => {
+    (async () => {
+      // const data = await getBoardDetail(Number(router.query.id));
+      // setDetailData(data);
+      setDetailData(DetailData);
+    })();
+  }, []);
+
+  const deleteHandler = async () => {
+    const deleteData = await deleteBoard(Number(detailData?.boardId));
+    if ((await deleteData) === 'ERR_BAD_REQUEST') {
+      return dispatch(
+        setModal({
+          isOpen: true,
+          onClickOk: () => dispatch(setModal({ isOpen: false })),
+          text: MESSAGES.COMMUNITY.ERROR_DELETE,
+        }),
+      );
+    } else {
+      return dispatch(
+        setModal({
+          isOpen: true,
+          text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
+          onClickOk: () => {
+            dispatch(
+              setModal({
+                isOpen: false,
+              }),
+            ),
+              router.push(ROUTES.ADMIN.REVIEW);
+          },
+        }),
+      );
+    }
+  };
+
+  return (
+    <Container>
+      <PageTitle title="후기 상세 정보" fontSize="20px" padding="10px" />
+      <DetailContent>
+        <Table>
+          <TableRow>
+            <TableCell align="center" width="15%">
+              후기 제목
+            </TableCell>
+            <TableCell align="left" width="30%">
+              {detailData && detailData.boardTitle}
+            </TableCell>
+            <TableCell align="center">작성자</TableCell>
+            <TableCell align="left">{detailData && detailData.userName}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell align="center" width="15%">
+              작성일
+            </TableCell>
+            <TableCell align="left" width="30%">
+              {detailData && detailData.createdDate}
+            </TableCell>
+            <TableCell align="center">수정일</TableCell>
+            <TableCell align="left">{detailData && detailData.updatedDate}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell align="center" colSpan={4}>
+              {detailData && Parser(detailData.boardContent)}
+            </TableCell>
+          </TableRow>
+        </Table>
+        <ButtonContent>
+          <button className="white" onClick={() => router.push(ROUTES.ADMIN.REVIEW_EDIT)}>
+            수정
+          </button>
+          <button className="blue" onClick={() => deleteHandler()}>
+            삭제
+          </button>
+        </ButtonContent>
+      </DetailContent>
+    </Container>
+  );
 };
 
 export default withAuth(ReviewDetail);
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-sizing: border-box;
+  position: relative;
+`;
+
+const DetailContent = styled.div`
+  margin-top: 2rem;
+`;
+
+const ButtonContent = styled.div`
+  margin-bottom: 5px;
+  margin-top: 20px;
+  text-align: right;
+  button {
+    border-radius: 8px;
+    margin: auto;
+    width: 5rem;
+    height: 2rem;
+    font-weight: 600;
+    border: 1px solid #0cb1f3;
+  }
+  .white {
+    color: #0cb1f3;
+    background-color: #fff;
+    margin-right: 10px;
+  }
+  .blue {
+    color: #fff;
+    background-color: #0cb1f3;
+  }
+`;

--- a/pages/admin/community/review/[id].tsx
+++ b/pages/admin/community/review/[id].tsx
@@ -13,6 +13,7 @@ import { ROUTES } from '@/constants/routes';
 import { useDispatch } from 'react-redux';
 import { setModal } from '@/store/modal';
 import { MESSAGES } from '@/constants/messages';
+import Image from '@/components/common/Image';
 
 const ReviewDetail = () => {
   const router = useRouter();
@@ -59,6 +60,16 @@ const ReviewDetail = () => {
       <PageTitle title="후기 상세 정보" fontSize="20px" padding="10px" />
       <DetailContent>
         <Table>
+          <TableRow>
+            <TableCell align="center">썸네일</TableCell>
+            <TableCell align="left" colSpan={3}>
+              <Image
+                src={router.query.image && String(router.query.image)}
+                alt={detailData && detailData.boardTitle}
+                width="330px"
+              />
+            </TableCell>
+          </TableRow>
           <TableRow>
             <TableCell align="center" width="15%">
               후기 제목

--- a/pages/admin/community/review/[id].tsx
+++ b/pages/admin/community/review/[id].tsx
@@ -27,32 +27,37 @@ const ReviewDetail = () => {
     })();
   }, []);
 
-  const deleteHandler = async () => {
-    const deleteData = await deleteBoard(Number(detailData?.boardId));
-    if ((await deleteData) === 'ERR_BAD_REQUEST') {
-      return dispatch(
-        setModal({
-          isOpen: true,
-          onClickOk: () => dispatch(setModal({ isOpen: false })),
-          text: MESSAGES.COMMUNITY.ERROR_DELETE,
-        }),
-      );
-    } else {
-      return dispatch(
-        setModal({
-          isOpen: true,
-          text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
-          onClickOk: () => {
-            dispatch(
+  const deleteHandler = () => {
+    return dispatch(
+      setModal({
+        isOpen: true,
+        onClickOk: async () => {
+          const deleteData = await deleteBoard(Number(detailData?.boardId));
+          if (deleteData === 'ERR_BAD_REQUEST') {
+            return dispatch(
               setModal({
-                isOpen: false,
+                isOpen: true,
+                onClickOk: () => dispatch(setModal({ isOpen: false })),
+                text: MESSAGES.COMMUNITY.ERROR_DELETE,
               }),
-            ),
-              router.push(ROUTES.ADMIN.REVIEW);
-          },
-        }),
-      );
-    }
+            );
+          } else {
+            return dispatch(
+              setModal({
+                isOpen: true,
+                onClickOk: () => {
+                  dispatch(setModal({ isOpen: false }));
+                  router.push(ROUTES.REVIEW);
+                },
+                text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
+              }),
+            );
+          }
+        },
+        onClickCancel: () => dispatch(setModal({ isOpen: false })),
+        text: MESSAGES.COMMUNITY.CONFIRM_DELETE,
+      }),
+    );
   };
 
   return (

--- a/pages/admin/community/review/add.tsx
+++ b/pages/admin/community/review/add.tsx
@@ -57,7 +57,7 @@ const ReviewAddForm = () => {
 
   const onSubmit = () => {
     const data = {
-      boardContent: JSON.stringify(editValue),
+      boardContent: editValue,
       boardThumbnail: fileUrl,
       boardTitle: keyword,
       boardType: '여행후기',

--- a/pages/admin/community/review/edit.tsx
+++ b/pages/admin/community/review/edit.tsx
@@ -16,7 +16,7 @@ const ReviewEditForm = () => {
 
   const onSubmit = () => {
     const data = {
-      boardContent: JSON.stringify(editValue),
+      boardContent: editValue,
       boardThumbnail: '',
       boardTitle: keyword,
       boardType: '여행후기',

--- a/pages/admin/community/review/edit.tsx
+++ b/pages/admin/community/review/edit.tsx
@@ -1,8 +1,158 @@
 import withAuth from '@/components/common/PrivateRouter';
-import React from 'react';
+import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
+import React, { useState } from 'react';
+import ArrowLeft from '@/../public/icons/arrow-left.svg';
+import { Button, TextField } from '@mui/material';
+import { ROUTES } from '@/constants/routes';
+import { patchBoardEdit } from '@/apis/community';
+import dayjs from 'dayjs';
+import Editor from '@/components/common/Editor';
 
 const ReviewEditForm = () => {
-  return <div>ReviewEditForm</div>;
+  const router = useRouter();
+  const [keyword, setKeyword] = useState('');
+  const [editValue, setEditValue] = useState<string>('');
+
+  const onSubmit = () => {
+    const data = {
+      boardContent: JSON.stringify(editValue),
+      boardThumbnail: '',
+      boardTitle: keyword,
+      boardType: '여행후기',
+    };
+
+    patchBoardEdit(Number(router.query.id), data);
+    router.push(ROUTES.ADMIN.REVIEW);
+  };
+
+  const now = dayjs();
+  const date = now.format('YYYY-MM-DD');
+
+  return (
+    <EditContent>
+      <BackRouter onClick={() => router.back()}>
+        <ArrowLeft />
+        <p>여행 후기 관리</p>
+      </BackRouter>
+
+      <TitleContent>
+        <p>제목</p>
+        <TextField
+          placeholder="제목을 입력해 주세요."
+          className="title"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+        />
+      </TitleContent>
+
+      <UserContent>
+        <span className="user">관리자</span>
+        <span>{date}</span>
+      </UserContent>
+
+      <EditorContent>
+        <Editor htmlStr={editValue} setHtmlStr={setEditValue} />
+      </EditorContent>
+
+      <ButtonContent>
+        <button className="white" onClick={() => router.back()}>
+          취소
+        </button>
+        <button
+          className="blue"
+          onClick={() => {
+            onSubmit();
+          }}
+        >
+          저장
+        </button>
+      </ButtonContent>
+    </EditContent>
+  );
 };
 
 export default withAuth(ReviewEditForm);
+
+const EditContent = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-sizing: border-box;
+  position: relative;
+`;
+
+const BackRouter = styled.div`
+  display: flex;
+  margin-bottom: 50px;
+  svg {
+    width: 30px;
+    margin-right: 10px;
+  }
+  p {
+    margin: auto 0;
+    font-size: 1.3rem;
+    color: #878787;
+  }
+`;
+
+const TitleContent = styled.div`
+  display: flex;
+  margin-bottom: 20px;
+  p {
+    font-size: 1.2rem;
+    color: #878787;
+    margin: auto 15px auto 0;
+  }
+  .title {
+    width: 50%;
+    input {
+      padding: 5px;
+      border: none;
+    }
+  }
+`;
+
+const TitleImage = styled.div``;
+
+const UserContent = styled.div`
+  color: #878787;
+  text-align: right;
+  margin-bottom: 20px;
+  margin-right: 5px;
+  .user {
+    margin-right: 10px;
+  }
+`;
+
+const EditorContent = styled.div`
+  height: 500px;
+  .rdw-editor-wrapper {
+    height: 100%;
+  }
+`;
+
+const ButtonContent = styled.div`
+  margin-bottom: 5px;
+  margin-top: 120px;
+  text-align: right;
+  button {
+    border-radius: 8px;
+    margin: auto;
+    width: 5rem;
+    height: 2rem;
+    font-weight: 600;
+    border: 1px solid #0cb1f3;
+  }
+  .white {
+    color: #0cb1f3;
+    background-color: #fff;
+    margin-right: 10px;
+  }
+  .blue {
+    color: #fff;
+    background-color: #0cb1f3;
+  }
+`;

--- a/pages/admin/community/review/index.tsx
+++ b/pages/admin/community/review/index.tsx
@@ -90,6 +90,7 @@ const Review = () => {
                         pathname: ROUTES.ADMIN.REVIEW_BY_ID(String(item.boardId)),
                         query: {
                           id: item.boardId,
+                          image: item.boardThumbnail,
                         },
                       },
                       ROUTES.ADMIN.REVIEW_BY_ID(String(item.boardId)),

--- a/pages/admin/community/review/index.tsx
+++ b/pages/admin/community/review/index.tsx
@@ -1,13 +1,191 @@
+import { getBoardList } from '@/apis/community';
+import AdminTableHead from '@/components/common/AdminTableHead';
 import PageTitle from '@/components/common/PageTitle';
 import withAuth from '@/components/common/PrivateRouter';
-import React from 'react';
+import { ROUTES } from '@/constants/routes';
+import { IReview } from '@/interfaces/community';
+import styled from '@emotion/styled';
+import { BsSearch } from 'react-icons/bs';
+import {
+  Button,
+  Pagination,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  TextField,
+} from '@mui/material';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+
+import ReviewList from '@/dummydata/CommunityReview.json';
 
 const Review = () => {
+  const router = useRouter();
+  const [review, setReview] = useState<Array<IReview>>([]);
+  const [keyword, setKeyword] = useState('');
+  const [page, setPage] = useState(1);
+  const [totalPage, setTotalPage] = useState(1);
+
+  useEffect(() => {
+    (async () => {
+      // const reviewData =
+      //   keyword !== ''
+      //     ? await getBoardList('TRAVEL_REVIEW', page)
+      //     : await getBoardList('TRAVEL_REVIEW', page, keyword);
+      // setReview(reviewData?.content);
+      // setTotalPage(reviewData.totalPages);
+      setReview(ReviewList.content);
+      setTotalPage(ReviewList.totalPages);
+    })();
+  }, []);
+
+  const getSearchData = async () => {
+    const searchData = await getBoardList('TRAVEL_REVIEW', 1, keyword);
+    setReview(searchData?.content);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if ((event.nativeEvent.isComposing === false && event.key) === 'Enter') {
+      getSearchData();
+    }
+  };
+
+  const searchClick = () => {
+    getSearchData();
+  };
+
+  const pageChange = (event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+  };
+
   return (
-    <div>
-      <PageTitle title="여행 후기 관리" />
-    </div>
+    <Container>
+      <PageTitle title="여행 후기 관리" fontSize="20px" padding="10px" />
+      <InputArea>
+        <TextField
+          placeholder="검색어를 입력해 주세요."
+          className="search"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <Button variant="outlined" className="searchBtn" onClick={() => searchClick()}>
+          <BsSearch size={23} />
+        </Button>
+      </InputArea>
+      <TableWrap>
+        <Table>
+          <AdminTableHead titles={['번호', '제목', '작성자', '작성일']} />
+          <TableBody>
+            {review && review.length > 0 ? (
+              review.map((item, idx) => (
+                <TableRow
+                  key={idx}
+                  style={{ cursor: 'pointer' }}
+                  hover
+                  onClick={() =>
+                    router.push(
+                      {
+                        pathname: ROUTES.ADMIN.REVIEW_BY_ID(String(item.boardId)),
+                        query: {
+                          id: item.boardId,
+                        },
+                      },
+                      ROUTES.ADMIN.REVIEW_BY_ID(String(item.boardId)),
+                    )
+                  }
+                >
+                  <TableCell align="center" width="200px">
+                    {(page - 1) * 10 + idx + 1}
+                  </TableCell>
+                  <TableCell align="center">{item.boardTitle}</TableCell>
+                  <TableCell align="center">{item.userName}</TableCell>
+                  <TableCell align="center">{item.createdDate}</TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={4}>
+                  <EmptyText>등록된 상품이 없습니다.</EmptyText>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+        <BottomArea>
+          {totalPage && (
+            <Pagination count={totalPage} color="primary" page={page} onChange={pageChange} />
+          )}
+          <Button
+            className="addBtn"
+            variant="outlined"
+            onClick={() => router.push(ROUTES.ADMIN.REVIEW_ADD)}
+          >
+            등록
+          </Button>
+        </BottomArea>
+      </TableWrap>
+    </Container>
   );
 };
 
 export default withAuth(Review);
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  border-radius: 10px;
+  padding: 20px;
+  box-sizing: border-box;
+  position: relative;
+`;
+
+const TableWrap = styled.div`
+  height: calc(100% - 40px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  margin-top: 2rem;
+`;
+
+const EmptyText = styled.p`
+  width: 100%;
+  font-size: 16px;
+  display: flex;
+  justify-content: center;
+`;
+
+const InputArea = styled.div`
+  text-align: center;
+  position: absolute;
+  top: 25px;
+  right: 4%;
+  .search {
+    width: 20rem;
+    border-radius: 8px;
+    margin-right: 1rem;
+    input {
+      padding: 5px;
+      background-color: #fff;
+    }
+  }
+  .searchBtn {
+    padding: 4px;
+  }
+`;
+
+const BottomArea = styled.div`
+  width: 100%;
+  position: relative;
+  ul {
+    justify-content: center;
+  }
+  .addBtn {
+    position: absolute;
+    right: 10px;
+    top: 0;
+  }
+`;

--- a/pages/admin/community/review/index.tsx
+++ b/pages/admin/community/review/index.tsx
@@ -114,7 +114,7 @@ const Review = () => {
           </TableBody>
         </Table>
         <BottomArea>
-          {totalPage && (
+          {totalPage > 1 && (
             <Pagination count={totalPage} color="primary" page={page} onChange={pageChange} />
           )}
           <Button

--- a/pages/community/notice/[id].tsx
+++ b/pages/community/notice/[id].tsx
@@ -5,8 +5,8 @@ import { formatUserName } from '@/utils/format';
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
-import { useCookies } from 'react-cookie';
 import { SlArrowUp, SlArrowDown } from 'react-icons/sl';
+import Parser from 'html-react-parser';
 
 const NoticeDetail = () => {
   const [detailData, setDetailData] = useState<IReviewDetail>();
@@ -20,12 +20,6 @@ const NoticeDetail = () => {
 
     getData();
   }, []);
-
-  // const markUp = () => {
-  //   if (detailData?.boardContent !== undefined) {
-  //     return { __html: JSON.parse(detailData?.boardContent) };
-  //   }
-  // };
 
   return (
     <DetailContent>
@@ -44,8 +38,7 @@ const NoticeDetail = () => {
       </SummaryContent>
 
       <MainContent>
-        {/* <div dangerouslySetInnerHTML={markUp()}></div> */}
-        <div>{detailData?.boardContent}</div>
+        <div>{detailData && Parser(detailData?.boardContent)}</div>
       </MainContent>
 
       {router.query.i !== '0' ? (

--- a/pages/community/notice/index.tsx
+++ b/pages/community/notice/index.tsx
@@ -7,7 +7,7 @@ import { Pagination, TextField } from '@mui/material';
 import SearchIcon from '@/../public/icons/Group.svg';
 import CommunityRouter from '@/components/Community/CommunityRouter';
 import NoticeItem from '@/components/Community/NoticeItem';
-import { getBoardList, getBoardSearchList } from '@/apis/community';
+import { getBoardList } from '@/apis/community';
 
 const Notice = () => {
   const router = useRouter();
@@ -18,14 +18,17 @@ const Notice = () => {
 
   useEffect(() => {
     (async () => {
-      const data = await getBoardList('NOTICE', page);
+      const data =
+        keyword !== ''
+          ? await getBoardList('NOTICE', page)
+          : await getBoardList('NOTICE', page, keyword);
       setNoticeData(data?.content);
       setTotalPage(data.totalPages);
     })();
   }, [page]);
 
   const getSearchData = async () => {
-    const searchData = await getBoardSearchList('NOTICE', keyword, 1);
+    const searchData = await getBoardList('NOTICE', 1, keyword);
     setNoticeData(searchData?.content);
   };
 

--- a/pages/community/notice/index.tsx
+++ b/pages/community/notice/index.tsx
@@ -78,7 +78,9 @@ const Notice = () => {
       </BottomArea>
 
       <PageContent>
-        <Pagination count={totalPage} color="primary" page={page} onChange={pageChange} />
+        {totalPage > 1 && (
+          <Pagination count={totalPage} color="primary" page={page} onChange={pageChange} />
+        )}
       </PageContent>
     </NoticeContent>
   );

--- a/pages/community/review/add.tsx
+++ b/pages/community/review/add.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import ArrowLeft from '@/../public/icons/arrow-left.svg';
 import { Button, TextField } from '@mui/material';
@@ -12,6 +12,9 @@ const Editor = dynamic(() => import('@/components/common/Editor'), { ssr: false 
 import dayjs from 'dayjs';
 import { postBoardAdd } from '@/apis/community';
 import { ROUTES } from '@/constants/routes';
+import { uploadImage } from '@/apis/common';
+import { getUserInfo } from '@/apis/main';
+import { useCookies } from 'react-cookie';
 
 const ReviewAdd = () => {
   const router = useRouter();
@@ -23,13 +26,34 @@ const ReviewAdd = () => {
   const [fileName, setFileName] = useState('');
   const [fileUrl, setFileUrl] = useState('');
 
-  const onUploadImage = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const [cookies, setCookies] = useCookies();
+  const [user, setUser] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      if (cookies.accessToken) {
+        const userData = await getUserInfo();
+        setUser(userData.userName);
+      }
+    })();
+  }, []);
+
+  const onUploadImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) {
       return;
     }
+
+    const file = e.target.files[0];
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+
+    reader.onloadend = async () => {
+      const res = await uploadImage(file as unknown as string, 'review');
+      setFileUrl(res);
+    };
+
     setFileName(e.target.files[0]?.name);
-    setFileUrl(URL.createObjectURL(e.target.files[0]));
-  }, []);
+  };
 
   const onUploadImageButtonClick = useCallback(() => {
     if (!inputRef.current) {
@@ -72,7 +96,7 @@ const ReviewAdd = () => {
       </TitleImage>
 
       <UserContent>
-        <span className="user">{formatUserName('홍길동')}</span>
+        <span className="user">{formatUserName(user)}</span>
         <span>{date}</span>
       </UserContent>
 
@@ -88,8 +112,8 @@ const ReviewAdd = () => {
           className="blue"
           onClick={() => {
             const data = {
-              boardContent: JSON.stringify(editValue),
-              boardThumbnail: JSON.stringify(fileUrl),
+              boardContent: editValue,
+              boardThumbnail: fileUrl,
               boardTitle: keyword,
               boardType: '여행후기',
             };

--- a/pages/community/review/edit.tsx
+++ b/pages/community/review/edit.tsx
@@ -98,7 +98,7 @@ const ReviewEdit = () => {
           className="blue"
           onClick={() => {
             const data = {
-              boardContent: JSON.stringify(editValue),
+              boardContent: editValue,
               boardThumbnail: fileUrl,
               boardTitle: keyword,
             };

--- a/pages/community/review/index.tsx
+++ b/pages/community/review/index.tsx
@@ -114,7 +114,9 @@ const Review = () => {
       </BottomArea>
 
       <PageContent>
-        <Pagination count={totalPage} color="primary" page={page} onChange={pageChange} />
+        {totalPage > 1 && (
+          <Pagination count={totalPage} color="primary" page={page} onChange={pageChange} />
+        )}
       </PageContent>
     </ReviewContent>
   );

--- a/pages/community/review/index.tsx
+++ b/pages/community/review/index.tsx
@@ -9,7 +9,7 @@ import SearchIcon from '@/../public/icons/Group.svg';
 import ReviewItem from '@/components/Community/ReviewItem';
 import CommunityRouter from '@/components/Community/CommunityRouter';
 import { ROUTES } from '@/constants/routes';
-import { getBoardList, getBoardSearchList } from '@/apis/community';
+import { getBoardList } from '@/apis/community';
 import { useDispatch } from 'react-redux';
 import { useCookies } from 'react-cookie';
 import { setModal } from '@/store/modal';
@@ -27,14 +27,17 @@ const Review = () => {
 
   useEffect(() => {
     (async () => {
-      const data = await getBoardList('TRAVEL_REVIEW', page);
+      const data =
+        keyword !== ''
+          ? await getBoardList('TRAVEL_REVIEW', page)
+          : await getBoardList('TRAVEL_REVIEW', page, keyword);
       setReviewData(data?.content);
       setTotalPage(data.totalPages);
     })();
   }, [page]);
 
   const getSearchData = async () => {
-    const searchData = await getBoardSearchList('TRAVEL_REVIEW', keyword, 1);
+    const searchData = await getBoardList('TRAVEL_REVIEW', 1, keyword);
     setReviewData(searchData?.content);
   };
 
@@ -53,7 +56,7 @@ const Review = () => {
   };
 
   const moveLogin = () => {
-    if (cookies.accessToken && cookies.length > 0) {
+    if (cookies.accessToken) {
       router.push(ROUTES.REVIEW_ADD);
     } else {
       return dispatch(

--- a/pages/mypage/order/[id].tsx
+++ b/pages/mypage/order/[id].tsx
@@ -33,16 +33,31 @@ const MyOrderDetail = () => {
     return dispatch(
       setModal({
         isOpen: true,
-        text: MESSAGES.MYPAGE.DELETE_REVERVATION,
-        onClick: () => {
-          deleteReservation(Number(detailData?.reservationDetailId));
-          dispatch(
-            setModal({
-              isOpen: false,
-            }),
-          );
-          router.push(ROUTES.MYPAGE.ORDER);
+        onClickOk: async () => {
+          const deleteData = await deleteReservation(Number(detailData?.reservationDetailId));
+          if (deleteData === 'ERR_BAD_REQUEST') {
+            return dispatch(
+              setModal({
+                isOpen: true,
+                onClickOk: () => dispatch(setModal({ isOpen: false })),
+                text: MESSAGES.MYPAGE.DELETE_REVERVATION_ERROR,
+              }),
+            );
+          } else {
+            return dispatch(
+              setModal({
+                isOpen: true,
+                onClickOk: () => {
+                  dispatch(setModal({ isOpen: false }));
+                  router.push(ROUTES.REVIEW);
+                },
+                text: MESSAGES.MYPAGE.DELETE_REVERVATION_COMPLETE,
+              }),
+            );
+          }
         },
+        onClickCancel: () => dispatch(setModal({ isOpen: false })),
+        text: MESSAGES.MYPAGE.DELETE_REVERVATION_CONFIRM,
       }),
     );
   };

--- a/pages/mypage/review/[id].tsx
+++ b/pages/mypage/review/[id].tsx
@@ -27,33 +27,39 @@ const MyReviewDetail = () => {
     })();
   });
 
-  const deleteHandler = async () => {
-    const deleteData = await deleteBoard(Number(detailData?.boardId));
-    if ((await deleteData) === 'ERR_BAD_REQUEST') {
-      return dispatch(
-        setModal({
-          isOpen: true,
-          onClickOk: () => dispatch(setModal({ isOpen: false })),
-          text: MESSAGES.COMMUNITY.ERROR_DELETE,
-        }),
-      );
-    } else {
-      return dispatch(
-        setModal({
-          isOpen: true,
-          text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
-          onClickOk: () => {
-            dispatch(
+  const deleteHandler = () => {
+    return dispatch(
+      setModal({
+        isOpen: true,
+        onClickOk: async () => {
+          const deleteData = await deleteBoard(Number(detailData?.boardId));
+          if (deleteData === 'ERR_BAD_REQUEST') {
+            return dispatch(
               setModal({
-                isOpen: false,
+                isOpen: true,
+                onClickOk: () => dispatch(setModal({ isOpen: false })),
+                text: MESSAGES.COMMUNITY.ERROR_DELETE,
               }),
-            ),
-              router.push(ROUTES.REVIEW);
-          },
-        }),
-      );
-    }
+            );
+          } else {
+            return dispatch(
+              setModal({
+                isOpen: true,
+                onClickOk: () => {
+                  dispatch(setModal({ isOpen: false }));
+                  router.push(ROUTES.REVIEW);
+                },
+                text: MESSAGES.COMMUNITY.COMPLETE_DELETE,
+              }),
+            );
+          }
+        },
+        onClickCancel: () => dispatch(setModal({ isOpen: false })),
+        text: MESSAGES.COMMUNITY.CONFIRM_DELETE,
+      }),
+    );
   };
+
   return (
     <Container>
       <MyPageNavbar />

--- a/pages/product/[id].tsx
+++ b/pages/product/[id].tsx
@@ -79,7 +79,7 @@ const ProductDetail = () => {
     })();
   }, []);
 
-  const productPrice = productDetail?.price as number;
+  const productPrice = Number(productDetail?.price);
 
   const SingleOption = [
     {
@@ -89,9 +89,9 @@ const ProductDetail = () => {
   ];
 
   const dateSelect = (option: any) => {
-    const optionDate = option?.label as string;
-    const optionId = option.id as number;
-    const count = option?.value as number;
+    const optionDate = option?.label;
+    const optionId = option.id;
+    const count = 1;
 
     if (items.some((item) => item.optionDate === optionDate)) {
       alert('이미 선택하신 옵션입니다.');
@@ -276,10 +276,10 @@ const ProductDetail = () => {
 
           <Select
             onChange={dateSelect}
-            options={productDetail?.productOptions?.map((item) => {
+            options={productDetail?.productOptions?.map((item, idx) => {
               return {
                 label: `${item.startDate} 출발 ~ ${item.endDate} 도착`,
-                value: 1,
+                value: idx,
                 id: item.productOptionId,
               };
             })}

--- a/src/apis/common.ts
+++ b/src/apis/common.ts
@@ -1,7 +1,7 @@
 import { API_URLS } from '@/constants/apiUrls';
 import { instance } from './instance';
 
-export const uploadImage = async (image: string, category: string) => {
+export const uploadImage = async (image: string | Blob, category: string) => {
   const form = new FormData();
   form.append('file', image);
 

--- a/src/apis/community.ts
+++ b/src/apis/community.ts
@@ -1,13 +1,8 @@
 import { API_URLS } from '@/constants/apiUrls';
 import { instance } from './instance';
 
-export const getBoardList = async (type: string, pageNumber: number) => {
-  const { data } = await instance.get(API_URLS.BOARD(type, pageNumber));
-  return data;
-};
-
-export const getBoardSearchList = async (type: string, keyword: string, pageNumber: number) => {
-  const { data } = await instance.get(API_URLS.BOARD_SEARCH(type, keyword, pageNumber));
+export const getBoardList = async (type: string, pageNumber: number, keyword?: string) => {
+  const { data } = await instance.get(API_URLS.BOARD(type, keyword, pageNumber));
   return data;
 };
 

--- a/src/components/Community/ReviewItem.tsx
+++ b/src/components/Community/ReviewItem.tsx
@@ -47,6 +47,9 @@ const ItemContent = styled.div<{ image: string }>`
   aspect-ratio: 1 / 1;
   filter: brightness(80%);
   background-image: url(${(props) => props.image});
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: 100% 100%;
   padding: 2rem;
   position: relative;
   &:hover {

--- a/src/components/common/Editor.tsx
+++ b/src/components/common/Editor.tsx
@@ -4,6 +4,7 @@ import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
 import { ContentState, convertToRaw, EditorState } from 'draft-js';
 import draftToHtml from 'draftjs-to-html';
 import htmlToDraft from 'html-to-draftjs';
+import { uploadImage } from '@/apis/common';
 
 interface IEditor {
   htmlStr: string;
@@ -29,20 +30,17 @@ const Editor = ({ htmlStr, setHtmlStr }: IEditor) => {
     setHtmlStr(draftToHtml(convertToRaw(editorState.getCurrentContent())));
   };
 
-  const uploadCallback = (file: Blob) => {
+  const uploadCallback = (file: Blob | string) => {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
 
       reader.onloadend = async () => {
-        const formData = new FormData();
-        formData.append('multipartFiles', file);
+        const res = await uploadImage(file as string, 'review');
 
-        const res = URL.createObjectURL(file);
-
-        resolve({ data: { link: res } });
+        resolve({ data: { link: res.data } });
       };
 
-      reader.readAsDataURL(file);
+      reader.readAsDataURL(file as Blob);
     });
   };
 

--- a/src/components/common/Editor.tsx
+++ b/src/components/common/Editor.tsx
@@ -30,17 +30,17 @@ const Editor = ({ htmlStr, setHtmlStr }: IEditor) => {
     setHtmlStr(draftToHtml(convertToRaw(editorState.getCurrentContent())));
   };
 
-  const uploadCallback = (file: Blob | string) => {
+  const uploadCallback = (file: Blob) => {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
 
       reader.onloadend = async () => {
-        const res = await uploadImage(file as string, 'review');
+        const url = await uploadImage(file, 'review');
 
-        resolve({ data: { link: res.data } });
+        resolve({ data: { link: url } });
       };
 
-      reader.readAsDataURL(file as Blob);
+      reader.readAsDataURL(file);
     });
   };
 

--- a/src/constants/apiUrls.ts
+++ b/src/constants/apiUrls.ts
@@ -25,11 +25,12 @@ export const API_URLS = {
   CART: '/cart',
   ORDER: '/order',
   WISHLIST: '/wishlist',
-  BOARD: (type: string, pageNumber: number) => `/board?type=${type}&pageNumber=${pageNumber}`,
+  BOARD: (type: string, keyword: string | null = '', pageNumber: number) =>
+    keyword === null
+      ? `/board?type=${type}&pageNumber=${pageNumber}`
+      : `/board?type=${type}&keyword=${keyword}&pageNumber=${pageNumber}`,
   BOARD_AUTH: (id: string) => `/board/authority/${id}`,
   BOARD_DETAIL: (id: number) => `/board/${id}`,
-  BOARD_SEARCH: (type: string, keyword: string, pageNumber: number) =>
-    `/board/search?type=${type}&keyword=${keyword}&pageNumber=${pageNumber}`,
   BOARD_ADD: '/board',
   BOARD_EDIT: (boardId: number) => `/board/${boardId}`,
   CATEGORY: '/categories',

--- a/src/constants/apiUrls.ts
+++ b/src/constants/apiUrls.ts
@@ -59,5 +59,5 @@ export const API_URLS = {
   POPULAR_PRODUCTS: (id: number | undefined) =>
     id ? `/page/popular/products?categoryId=${id}` : '/page/popular/products',
   GROUP_PRODUCTS: '/page/group/products',
-  USER_INFO: '/user/info',
+  USER_INFO: '/user/myInfo',
 };

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -62,10 +62,13 @@ export const MESSAGES = {
   MOVE_TO_SIGNUP: '계정이 없으신가요? 그렇다면 회원가입 페이지로 이동해 주세요.',
   COMMUNITY: {
     MOVE_TO_LOGIN: '회원 전용 메뉴입니다.\n로그인 후 이용해 주세요.',
-    ERROR_DELETE: '권한이 없어 삭제가 불가능합니다.',
+    ERROR_DELETE: '에러가 발생하였습니다.',
+    CONFIRM_DELETE: '삭제하시겠습니까?',
     COMPLETE_DELETE: '삭제가 완료되었습니다.',
   },
   MYPAGE: {
-    DELETE_REVERVATION: '삭제가 완료되었습니다.',
+    DELETE_REVERVATION_CONFIRM: '예약을 취소 하시겠습니까?',
+    DELETE_REVERVATION_COMPLETE: '취소가 완료되었습니다.',
+    DELETE_REVERVATION_ERROR: '에러가 발생하였습니다.',
   },
 };

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -60,6 +60,7 @@ export const ROUTES = {
     NOTICE_EDIT: '/admin/community/notice/edit',
     REVIEW: '/admin/community/review',
     REVIEW_BY_ID: (id: string) => `/admin/community/review/${id}`,
+    REVIEW_ADD: '/admin/community/review/add',
     REVIEW_EDIT: '/admin/community/review/edit',
     BANNER: '/admin/banner',
     BANNER_BY_ID: (id: string) => `/admin/banner/${id}`,


### PR DESCRIPTION
# 📍 이슈 번호
#118 
<!-- 이슈 완료 시 close 추가 -->

# 📚 작업 내용
- 여행 후기 관리 페이지 구현 ( + 공지사항 페이지 구현 - 구조는 비슷합니다)

![스크린샷 2023-04-08 오후 9 04 21](https://user-images.githubusercontent.com/107393773/230720151-8034241c-cc52-4e02-b83e-57e13103c582.png)

![스크린샷 2023-04-08 오후 9 04 29](https://user-images.githubusercontent.com/107393773/230720157-3db2678d-6b2d-4766-98d4-05e838eaf984.png)


# 💬 특이 사항
+ 추가 수정 사항
- 상품 상세 페이지 select 관련 오류 수정하였습니다.
    => 이거는 option의 value가 모두 같거나 없을때 일어나는 현상 같습니다.
- board list 불러오는 api 가 수정되어 코드를 맞게 수정하였습니다.
- 글을 삭제하거나 예약을 삭제할 때 한번더 물어보도록 수정하였습니다.
- 이미지를 받는 부분은 모두 이미지 api를 사용하도록 수정하였습니다.
- 이 외에도 자잘하게 수정하였습니다.