### PR TITLE
상품 목록에 태그 추가 / 모바일 검색 페이지 레이아웃 수정 / 여행 유형 테스트 결과 텍스트 추가

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -16,6 +16,7 @@ export default function Document() {
         <meta property="og:url" content="https://go-together.vercel.app/" />
         <meta property="og:site_name" content="고투게더" />
         <link rel="icon" href="/favicon.ico" />
+        <title>고투게더</title>
       </Head>
       <body>
         <Main />

--- a/pages/product/index.tsx
+++ b/pages/product/index.tsx
@@ -30,10 +30,15 @@ const Product = () => {
   const [showProduct, setShowProduct] = useState(false);
 
   useEffect(() => {
-    return () => {
-      setProduct([]);
-    };
-  }, []);
+    setProduct([]);
+    setDateOption(null);
+    setPeople(0);
+    setSort('recent');
+    setKeyword('');
+    setShowProduct(false);
+    setTotalCount(0);
+    setTotalPage(0);
+  }, [router]);
 
   const CustomInput = (
     props: React.HTMLProps<HTMLInputElement>,

--- a/pages/survey/index.tsx
+++ b/pages/survey/index.tsx
@@ -28,6 +28,7 @@ import { useDispatch } from 'react-redux';
 import { setModal } from '@/store/modal';
 import { MESSAGES } from '@/constants/messages';
 import withAuth from '@/components/common/PrivateRouter';
+import { formatMbtiToText } from '@/utils/format';
 
 const Servey = () => {
   const dispatch = useDispatch();
@@ -140,6 +141,7 @@ const Servey = () => {
 
       {activeStep === steps.length ? (
         <CardContainer>
+          <TypeText>{formatMbtiToText(answer.join(''))}</TypeText>
           <SurveyCard>
             <SurveyText>
               {`고투게더가 추천해 드리는 상품들을 살펴보시고,\n여행 계획을 세워보세요.`}
@@ -147,8 +149,8 @@ const Servey = () => {
             <ProductWrap>
               <Swiper
                 modules={[Pagination, Navigation, Autoplay]}
-                spaceBetween={30}
-                slidesPerView={2}
+                spaceBetween={10}
+                slidesPerView={3}
                 loop={true}
                 autoplay={{
                   delay: 2000,
@@ -165,10 +167,7 @@ const Servey = () => {
               </Swiper>
             </ProductWrap>
           </SurveyCard>
-          <Box sx={{ display: 'flex', flexDirection: 'row', pt: 2 }}>
-            <Box sx={{ flex: '1 1 auto' }} />
-            <Button onClick={handleReset}>다시하기</Button>
-          </Box>
+          <Button onClick={handleReset}>다시하기</Button>
         </CardContainer>
       ) : (
         <CardContainer>
@@ -276,8 +275,13 @@ const QuestionText = styled.p`
   white-space: pre-wrap;
 `;
 
+const TypeText = styled.p`
+  font-size: 18px;
+  font-weight: 600;
+`;
+
 const ProductWrap = styled.div`
-  width: 920px;
+  width: 1000px;
   color: black;
   display: flex;
   align-items: center;

--- a/src/components/Mypage/Wish/WishCard.tsx
+++ b/src/components/Mypage/Wish/WishCard.tsx
@@ -70,7 +70,6 @@ export default WishCard;
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  cursor: pointer;
   gap: 10px;
   width: 100%;
   position: relative;
@@ -83,7 +82,6 @@ const Title = styled.p`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  /* width: 334px; */
   @media (max-width: 1200px) {
     font-size: 14px;
     width: 43vw;

--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -4,6 +4,7 @@ import { formatPrice } from '@/utils/format';
 import { useRouter } from 'next/router';
 import React from 'react';
 import styled from '@emotion/styled';
+import { Chip } from '@mui/material';
 
 interface Props {
   data: IProduct;
@@ -19,6 +20,18 @@ const ProductCard = ({ data }: Props) => {
   return (
     <Container onClick={handleClick}>
       <ProductImg src={data.productThumbnail} alt={data.productName} />
+      {data.productSummary![0] === '#' && (
+        <ChipContainer>
+          {data.productSummary
+            ?.split(' ')!
+            .slice(0, 4)
+            .map((item, idx) => {
+              if (item[0] === '#') {
+                return <Chip key={idx} label={item} variant="outlined" color="primary" />;
+              }
+            })}
+        </ChipContainer>
+      )}
       <Title> {data.productName}</Title>
       <Price>{formatPrice(data.productPrice)}</Price>
     </Container>
@@ -33,6 +46,7 @@ const Container = styled.div`
   cursor: pointer;
   gap: 10px;
   width: 386px;
+  margin-bottom: 10px;
   @media (max-width: 1200px) {
     width: 43vw;
   }
@@ -48,14 +62,20 @@ const ProductImg = styled.img`
   }
 `;
 
+const ChipContainer = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 2px;
+`;
+
 const Title = styled.p`
   font-size: 1.4rem;
   font-weight: 600;
-  margin-top: 10px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 334px;
+  width: 386px;
+  margin-top: 4px;
   @media (max-width: 1200px) {
     font-size: 1.1rem;
     width: 43vw;

--- a/src/components/Product/SurveyProductCard.tsx
+++ b/src/components/Product/SurveyProductCard.tsx
@@ -32,15 +32,15 @@ const Container = styled.div`
   flex-direction: column;
   cursor: pointer;
   gap: 10px;
-  width: 23vw;
+  width: 324px;
   @media (max-width: 1200px) {
     width: 35vw;
   }
 `;
 
 const ProductImg = styled.img`
-  width: 23vw;
-  height: 23vw;
+  width: 324px;
+  height: 324px;
   border-radius: 10px;
   @media (max-width: 1200px) {
     width: 35vw;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,6 +11,7 @@ import MenuList from './header/MenuList';
 import Navbar from './Navbar';
 import { Button } from '@mui/material';
 import { mypageLogout } from '../Mypage/apis';
+import { ROUTES } from '@/constants/routes';
 
 const Header = () => {
   const [cookies, setCookies, removeCookies] = useCookies();
@@ -44,15 +45,19 @@ const Header = () => {
             {router.asPath !== '/product' && <Search />}
             <MyCartHeader />
             <MenuList />
+            {cookies.accessToken && cookies.refreshToken ? (
+              <Button
+                onClick={() => {
+                  mypageLogout(dispatch, router, cookies, removeCookies);
+                }}
+              >
+                로그아웃
+              </Button>
+            ) : (
+              <Button onClick={() => router.push(ROUTES.LOGIN)}>로그인</Button>
+            )}
           </Menus>
         )}
-        <Button
-          onClick={() => {
-            mypageLogout(dispatch, router, cookies, removeCookies);
-          }}
-        >
-          로그아웃
-        </Button>
       </HeaderContainer>
       <NavContainer>
         <Navbar />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -49,7 +49,7 @@ const Layout = ({ children }: Props) => {
               <Header />
             </div>
           )}
-          <Main>{children}</Main>
+          <Main isSearch={router.asPath === '/product'}>{children}</Main>
           <Footer />
           <ScrollTop />
           <Modal />
@@ -70,11 +70,11 @@ const Container = styled.div`
   }
 `;
 
-const Main = styled.div`
+const Main = styled.div<{ isSearch: boolean }>`
   margin-bottom: 90px;
   padding-top: 150px;
   @media (max-width: 1200px) {
-    padding-top: 70px;
+    padding-top: ${(props) => (props.isSearch ? '0' : '70px')};
   }
 `;
 
@@ -88,6 +88,7 @@ const AdminWrap = styled.div`
   display: flex;
   width: 100%;
 `;
+
 const Product = styled.div`
   @media (max-width: 1200px) {
     display: none;

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -12,7 +12,6 @@ const datas = {
     { categoryId: 101, categoryName: '커뮤니티', children: [] },
     { categoryId: 102, categoryName: '마이페이지', children: [] },
     { categoryId: 103, categoryName: '로그인', children: [] },
-    { categoryId: 104, categoryName: '장바구니', children: [] },
   ],
 };
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -11,7 +11,6 @@ const datas = {
   children: [
     { categoryId: 101, categoryName: '커뮤니티', children: [] },
     { categoryId: 102, categoryName: '마이페이지', children: [] },
-    { categoryId: 103, categoryName: '로그인', children: [] },
   ],
 };
 

--- a/src/components/layout/header/MyCartHeader.tsx
+++ b/src/components/layout/header/MyCartHeader.tsx
@@ -7,8 +7,8 @@ import React from 'react';
 const MyCartHeader = () => {
   return (
     <Container>
-      <Link href={ROUTES.MYPAGE.ORDER}>
-        <Image src="/icons/HeaderCart.svg" alt="예약확인페이지로 이동" width={24} height={24} />
+      <Link href={ROUTES.CART}>
+        <Image src="/icons/HeaderCart.svg" alt="장바구니" width={24} height={24} />
       </Link>
     </Container>
   );

--- a/src/interfaces/product.ts
+++ b/src/interfaces/product.ts
@@ -3,7 +3,12 @@ export interface IProduct {
   productName: string;
   productPrice: number;
   productThumbnail: string;
+  productSummary?: string;
   productStatus?: string;
+  categories?: {
+    categoryName: string;
+    categoryId: number;
+  }[];
 }
 
 export interface IProductDetail {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -43,31 +43,41 @@ export const formatTypeToMbti = (value: string) => {
   }
 };
 
-// export const formatMbtiToType = (value: string) => {
-//   switch (value) {
-//     case 'ESFJ':
-//     case 'INFJ':
-//     case 'INFP':
-//       return 'A';
-//     case 'ENTP':
-//     case 'INTJ':
-//       return 'B';
-//     case 'ESTJ':
-//     case 'ISTP':
-//       return 'C';
-//     case 'ESFP':
-//     case 'ESTP':
-//     case 'INTP':
-//     case 'ISFP':
-//       return 'D';
-//     case 'ENFJ':
-//     case 'ENTJ':
-//       return 'E';
-//     case 'ENFP':
-//     case 'ISFJ':
-//     case 'ISTJ':
-//       return 'F';
-//     default:
-//       return '';
-//   }
-// };
+export const formatMbtiToText = (value: string) => {
+  switch (value) {
+    case 'ESFJ':
+      return '누구에게라도 먼저 다가가 기꺼이 손을 뻗는 마당발 타입';
+    case 'INFJ':
+      return '차분하게 주변 사람들을 복돋아주는 다정한 타입';
+    case 'INFP':
+      return '늘 함께하는 이들을 위해 최선을 다하는 헌신가 타입';
+    case 'ENTP':
+      return '새로운 도전거리에 거리낌이 없고 뭐든 창조해내는 타입';
+    case 'INTJ':
+      return '계획적이면서도 새로운 것에 대해 열린 마음의 소유자 타입';
+    case 'ESTJ':
+      return '맡겨진 것이 무엇이든 최고의 성과를 도출하는 데 탁월한 타입';
+    case 'ISTP':
+      return '어떤 상황에서도 뚝딱뚝딱 해결책을 내어놓는 팔방미인 타입';
+    case 'ESFP':
+      return '순발력있는 재치와 열정으로 유쾌함을 전하는 에너지 소유자 타입';
+    case 'ESTP':
+      return '면밀하게 관찰하고 영리하게 리스크를 즐기는 도전정신을 가진 타입';
+    case 'INTP':
+      return '계획적으로 다가올 상황에 대처할 방법을 찾는 전략가 타입';
+    case 'ISFP':
+      return '호기심이 많고 유연하며 매력넘치는 예술가 타입';
+    case 'ENFJ':
+      return '그룹 내에서 진취적으로 도전하며 이끄는 카리스마를 가진 타입';
+    case 'ENTJ':
+      return '상상력 넘치는 비젼으로 공동체를 이끄는 지도자 타입';
+    case 'ENFP':
+      return '처음 보는 사람과도 쉽게 친해지는 긍정주의자 타입';
+    case 'ISFJ':
+      return '성실하고 책임감 있게 행동하는 온화한 성격의 소유자 타입';
+    case 'ISTJ':
+      return '주어진 조건 내에서 믿음직한 모습을 보여주는 성실한 타입';
+    default:
+      return '';
+  }
+};


### PR DESCRIPTION
# 📍 이슈 번호
#9
#23

<!-- 이슈 완료 시 close 추가 -->

# 📚 작업 내용
- 상품 목록 카드에 상품 요약으로 태그 추가
- 모바일 사이즈에서 검색 페이지 위에 padding 사라지도록 수정
- 헤더 아이콘 링크 장바구니로 수정
- 로그인 상태일 경우 로그아웃 버튼, 비회원 상태일 경우 로그인 버튼 출력
- 여행 유형 테스트 결과 텍스트 추가
- 여행 유형 테스트 추천 상품 목록 swiper 에서 3개씩 보여주도록 수정
- 카테고리별 상품 목록 조회 시 검색 조건 초기화
- _document.tsx 에 title 태그 추가


# 💬 특이 사항
![스크린샷 2023-04-13 오전 11 19 16](https://user-images.githubusercontent.com/87680906/231630373-eaae4a0e-73b4-463f-b891-a38cd68eeaad.png)
![스크린샷 2023-04-13 오전 11 19 39](https://user-images.githubusercontent.com/87680906/231630447-a80fc565-d837-45ba-97a7-c2ba43eb7dd3.png)
![스크린샷 2023-04-13 오전 11 23 20](https://user-images.githubusercontent.com/87680906/231631081-4280d4b6-c16a-46b6-8d26-3f5d58435570.png)
